### PR TITLE
[23] Bug fix

### DIFF
--- a/src/web/apps/web/eslint.config.mjs
+++ b/src/web/apps/web/eslint.config.mjs
@@ -13,6 +13,7 @@ import uiArchitectureRules from './.eslint/ui-architecture.mjs';
 import importRules from './.eslint/import.mjs';
 import unusedImportsRules from './.eslint/unused-imports.mjs';
 import unicornRules from './.eslint/unicorn.mjs';
+import { off } from 'cluster';
 
 const sharedRules = {
   rules: {
@@ -174,17 +175,7 @@ export default [
     files: ['src/lib/env.public.ts', 'src/lib/env.server.ts'],
     rules: {
       'no-restricted-properties': 'off',
-      'no-restricted-syntax': [
-        'error',
-        {
-          // Disallow: process.env.SOMETHING
-          // (but allow: process.env[name])
-          selector:
-            'MemberExpression[object.object.name="process"][object.property.name="env"][computed=false]',
-          message:
-            'Do not use process.env.VAR. Use requiredPublic("NEXT_PUBLIC_*") / requiredServer("VAR") helpers.',
-        },
-      ],
+      'no-restricted-syntax': 'off',
     },
   },
 ];


### PR DESCRIPTION
This pull request makes minor adjustments to the ESLint configuration for the web app, primarily disabling certain linting rules related to restricted syntax and properties in environment files.

- **ESLint Rule Updates:**
  - Disabled the `'no-restricted-syntax'` rule entirely for `src/lib/env.public.ts` and `src/lib/env.server.ts`, instead of specifying a custom restriction on `process.env` usage. (`src/web/apps/web/eslint.config.mjs`)
  - Disabled the `'no-restricted-properties'` rule for the same files. (`src/web/apps/web/eslint.config.mjs`)

- **Code Import Change:**
  - Added an unused import of `{ off }` from the `cluster` module, which appears to be unnecessary and may be accidental. (`src/web/apps/web/eslint.config.mjs`)