### PR TITLE
Enviroments changed for docker- compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ $RECYCLE.BIN/
 # -------------------
 .env
 .env.local
+.env.development
 
 secrets/
 .private/
@@ -76,7 +77,3 @@ pnpm-debug.log*
 # TypeScript
 # ------------------------------
 **/*.tsbuildinfo
-
-src/backend/docker/.env.development
-
-

--- a/src/backend/app/src/shared/db.pool.ts
+++ b/src/backend/app/src/shared/db.pool.ts
@@ -1,8 +1,3 @@
 import { Pool } from "pg";
 
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) throw new Error("DATABASE_URL is missing");
-
-export const pool = new Pool({
-  connectionString,
-});
+export const pool = new Pool();

--- a/src/backend/docker/.env.development.example
+++ b/src/backend/docker/.env.development.example
@@ -1,13 +1,10 @@
 # -----------------------------
 # Database
 # -----------------------------
-POSTGRES_USER=USER_HERE
-POSTGRES_PASSWORD=PASWORD_HERE
-POSTGRES_DB=app
-POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
-
-DATABASE_URL=postgresql://app:change-me@postgres:5432/app?schema=public
+PGUSER=app
+PGPASSWORD=change-me
+PGHOST=postgres
+PGDATABASE=app
 
 # -----------------------------
 # Sessions

--- a/src/database/docker/.env.development.example
+++ b/src/database/docker/.env.development.example
@@ -1,0 +1,6 @@
+# -----------------------------
+# Database
+# -----------------------------
+POSTGRES_USER=app
+POSTGRES_PASSWORD=change-me
+POSTGRES_DB=app

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -3,10 +3,8 @@ services:
     image: postgres:16-alpine
     container_name: app_postgres
     restart: unless-stopped
-    environment:
-      POSTGRES_DB: app
-      POSTGRES_USER: app
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    env_file:
+      - ./database/docker/.env.development
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -52,15 +50,13 @@ services:
       context: ./backend
       dockerfile: ./docker/Dockerfile
     working_dir: /app
-    env_file:
-      - ./backend/docker/.env.development
     expose:
       - "4000"
     depends_on:
       postgres:
         condition: service_healthy
-    environment:
-      DATABASE_URL: ${DATABASE_URL}
+    env_file:
+      - ./backend/docker/.env.development
     volumes:
       - ./backend/app:/app
       - node_modules_backend:/app/node_modules


### PR DESCRIPTION
This pull request refactors how database configuration is managed across the backend and database services, aiming for greater consistency and better use of environment files. The changes standardize environment variable names for PostgreSQL, update example environment files, and adjust how Docker Compose loads these variables.

**Database configuration standardization:**

* Updated the backend's database pool initialization in `db.pool.ts` to use default environment variables expected by the `pg` library, removing the direct use of `DATABASE_URL`.
* Changed environment variable names in `src/backend/docker/.env.development.example` to use `PGUSER`, `PGPASSWORD`, `PGHOST`, and `PGDATABASE`, matching the standard `pg` library expectations.
* Added a new example environment file `src/database/docker/.env.development.example` for the database service, specifying `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`.

**Docker Compose environment management:**

* Modified `docker-compose.yml` to load database service environment variables from the new `./database/docker/.env.development` file using `env_file`, instead of specifying them inline.
* Adjusted `docker-compose.yml` to ensure the backend service loads its environment from `./backend/docker/.env.development` using `env_file`, aligning with the new variable naming convention.Change the environment setting for the compose to files.