### PR TITLE
UI [108] Typography change

### DIFF
--- a/src/web/apps/web/src/app/layout.tsx
+++ b/src/web/apps/web/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
-import { Quicksand } from 'next/font/google';
-import { JetBrains_Mono } from 'next/font/google';
+import { Atkinson_Hyperlegible_Next, JetBrains_Mono } from 'next/font/google';
 import { getLocale } from 'next-intl/server';
 import './globals.css';
 
@@ -9,7 +8,7 @@ const mono = JetBrains_Mono({
   variable: '--font-mono',
 });
 
-export const quicksand = Quicksand({
+export const primary = Atkinson_Hyperlegible_Next({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
   variable: '--font-primary',
@@ -32,7 +31,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   const locale = await getLocale();
 
   return (
-    <html lang={locale} className={`${quicksand.variable} ${mono.variable}`}>
+    <html lang={locale} className={`${primary.variable} ${mono.variable}`}>
       <body className="h-screen flex">{children}</body>
     </html>
   );


### PR DESCRIPTION
This pull request updates the primary font used in the web application's layout. The previous `Quicksand` font has been replaced with `Atkinson_Hyperlegible_Next` to improve readability and accessibility. All references to the old font have been updated accordingly.

Font update:

* Replaced the `Quicksand` font with `Atkinson_Hyperlegible_Next` as the primary font in `layout.tsx`, including import statements and variable names. [[1]](diffhunk://#diff-1e838d0592e4f6e00ed997552ff881351c2311f5b6be5cca285f65def456753dL2-R2) [[2]](diffhunk://#diff-1e838d0592e4f6e00ed997552ff881351c2311f5b6be5cca285f65def456753dL12-R11) [[3]](diffhunk://#diff-1e838d0592e4f6e00ed997552ff881351c2311f5b6be5cca285f65def456753dL35-R34)