### PR TITLE
UI [#110] Navbar icon size and locale switcher

### DIFF
--- a/src/web/apps/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
+++ b/src/web/apps/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
@@ -3,7 +3,7 @@ import { cn } from '@/lib/styles/cn';
 const groupBase = ['inline-flex items-stretch flex-col', 'border border-black'];
 
 const itemBase = [
-  'relative inline-flex items-center justify-center px-4 py-2 text-sm font-medium',
+  'relative inline-flex items-center justify-center min-w-6 min-h-6 text-sm font-medium',
   'border-r border-black last:border-r-0',
   'text-black bg-white',
   'transition-colors',

--- a/src/web/apps/web/src/features/main-nav/navigation-footer/navigation-footer.tsx
+++ b/src/web/apps/web/src/features/main-nav/navigation-footer/navigation-footer.tsx
@@ -1,9 +1,11 @@
+import { LocaleSwitcher } from '@/features/locale-switcher';
 import { Icon } from '@components/primitives/icon';
 
 export function NavigationFooter() {
   return (
     <div className="flex flex-col gap-2 items-center">
-      <Icon name="settings" />
+      <Icon name="settings" size="20" />
+      <LocaleSwitcher />
     </div>
   );
 }

--- a/src/web/apps/web/src/features/main-nav/navigation-header/navigation-header.tsx
+++ b/src/web/apps/web/src/features/main-nav/navigation-header/navigation-header.tsx
@@ -9,11 +9,12 @@ export function NavigationHeader() {
   const { isExpanded, toggleExpanded } = useNavigationContext();
   return (
     <Button className={headerStyles.wrapper} variant="ghost" onPress={toggleExpanded}>
-      <Icon name="app" className={headerStyles.app} />
+      <Icon name="app" className={headerStyles.app} size={20} />
       <Icon
         name={isExpanded ? 'collapse' : 'expand'}
         aria-label={isExpanded ? 'expand' : 'collapse'}
         className={headerStyles.expand}
+        size={20}
       />
     </Button>
   );

--- a/src/web/apps/web/src/features/main-nav/navigation-main/navigation-main.tsx
+++ b/src/web/apps/web/src/features/main-nav/navigation-main/navigation-main.tsx
@@ -27,7 +27,7 @@ function isNavItemCurrent(pathname: string, href: string, exact?: boolean) {
 function renderNavLinkContent(icon: NavItem['icon'], label: string, isExpanded: boolean) {
   return (
     <>
-      <Icon name={icon} />
+      <Icon name={icon} size={20} />
       {isExpanded ? <span>{label}</span> : null}
     </>
   );


### PR DESCRIPTION
This pull request introduces several UI improvements to the navigation components, focusing on consistent icon sizing and enhanced accessibility. Additionally, it adds a locale switcher to the navigation footer for improved user experience.

**Navigation UI improvements:**

* Standardized all `Icon` components in navigation headers, footers, and main items to use a consistent `size={20}` prop for visual consistency. [[1]](diffhunk://#diff-04619ddb23cfcc98fc5be0ae3d504c0260f2689a9b5968600bb87c58151e269bL12-R17) [[2]](diffhunk://#diff-d7b5d6d79d25882f56fde4ef27fe2567557a663d96d84fd3ec01f0efcc02c3feR1-R8) [[3]](diffhunk://#diff-94ea2d017e142d989965a373a147a514852f02b898df6973f22d31ea79923222L30-R30)

**New features:**

* Added the `LocaleSwitcher` component to the navigation footer, enabling users to change the application language directly from the navigation area.

**Style adjustments:**

* Updated the segmented control group item styles to include minimum width and height (`min-w-6 min-h-6`) for improved alignment and touch target size.