### PR TITLE
FIX [#113] Restore deleted components

### DIFF
--- a/containers/contracts/sockets/chat/chat.schema.ts
+++ b/containers/contracts/sockets/chat/chat.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+import { VALIDATION, type ValidationCode } from '../../api/http/validation';
+
+// ---------------------------------------------------------------- Client to Server Schema start
+export const ChatSendSchema = z.object({
+  text: z
+    .string()
+    .trim()
+    .min(1, { message: VALIDATION.REQUIRED })
+    .max(300, { message: VALIDATION.FIELD_TOO_LONG })
+    .transform((val: string) => val.trim()),
+});
+
+export type ChatSend = z.infer<typeof ChatSendSchema>;
+// ---------------------------------------------------------------- Client to Server Schema end
+// ---------------------------------------------------------------- Server to Client Schema start
+// ---------------------------------------------------------------- Message Schema start
+export const ChatMessageSchema = z.object({
+  username: z.string(),
+  content: z.object({
+    text: z.string(),
+  }),
+  createdAt: z.number(),
+});
+
+export type ChatMessage = z.infer<typeof ChatMessageSchema>;
+// ---------------------------------------------------------------- Message Schema end
+// ---------------------------------------------------------------- Error Handling start
+
+export const CHAT_ERRORS = ['INVALID_CHAT_MESSAGE'] as const;
+type ChatErrorCode = (typeof CHAT_ERRORS)[number];
+
+type ZodValidationError = {
+  fieldName: PropertyKey[];
+  errCode: ValidationCode;
+};
+
+export type ChatError = {
+  code: ChatErrorCode;
+  details?: ZodValidationError[];
+};
+
+// ---------------------------------------------------------------- Error Handling end
+
+export const ChatSystemMessageSchema = z.object({
+  type: z.enum(['USER_JOINED', 'USER_LEFT']),
+  username: z.string().optional(),
+  createdAt: z.number(),
+});
+
+export const ChatHistorySchema = z.object({
+  messages: z.array(ChatMessageSchema),
+});
+
+export type ChatSystemMessage = z.infer<typeof ChatSystemMessageSchema>;
+export type ChatHistory = z.infer<typeof ChatHistorySchema>;
+// ---------------------------------------------------------------- Server to Client Schema end

--- a/containers/frontend/web/src/app/[locale]/(public)/ui/text-area/page.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/ui/text-area/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useState } from 'react';
+import { TextAreaField } from '@components/composites/text-area-field';
+import { Stack } from '@components/primitives/stack';
+import { Text } from '@components/primitives/text';
+
+export default function TextAreaPage() {
+  const [value, setValue] = useState('');
+  const handleChange = (value: string) => setValue(value);
+  return (
+    <Stack className="p-6 w-[400px]">
+      <Text as="h1" variant="heading-lg">
+        Text area component
+      </Text>
+      <TextAreaField value={value} onChange={handleChange} aria-label="message" maxLength={300} />
+    </Stack>
+  );
+}

--- a/containers/frontend/web/src/components/composites/text-area-field/index.ts
+++ b/containers/frontend/web/src/components/composites/text-area-field/index.ts
@@ -1,0 +1,2 @@
+export { TextAreaField } from './text-area-field';
+export type { TextAreaFieldProps } from './text-area-field';

--- a/containers/frontend/web/src/components/composites/text-area-field/text-area-field.styles.ts
+++ b/containers/frontend/web/src/components/composites/text-area-field/text-area-field.styles.ts
@@ -1,0 +1,7 @@
+const root = 'grid gap-1.5';
+const error = 'font-body-xs text-destructive';
+const counter =
+  'pointer-events-none font-caption col-start-1 row-start-1 self-end justify-self-end p-2';
+const input = 'col-start-1 row-start-1';
+
+export const textAreaFieldStyles = { root, input, error, counter };

--- a/containers/frontend/web/src/components/composites/text-area-field/text-area-field.tsx
+++ b/containers/frontend/web/src/components/composites/text-area-field/text-area-field.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { FieldError, Text, TextField as AriaTextField } from 'react-aria-components';
+import type { TextFieldProps as AriaTextFieldProps } from 'react-aria-components';
+import { useTranslations } from 'next-intl';
+import { TextArea, type TextAreaProps } from '@components/controls/text-area';
+import { textAreaFieldStyles } from './text-area-field.styles';
+
+type I18nKey = string;
+
+export type TextAreaFieldProps = Omit<
+  AriaTextFieldProps,
+  'children' | 'className' | 'value' | 'defaultValue' | 'onChange'
+> & {
+  'aria-label': string;
+  errorKey?: I18nKey;
+  onChange: (value: string) => void;
+  textAreaProps?: Omit<TextAreaProps, 'value' | 'defaultValue' | 'onChange' | 'maxLength' | 'className'>;
+  value: string;
+};
+
+export function TextAreaField(props: TextAreaFieldProps) {
+  const {
+    'aria-label': ariaLabel,
+    errorKey,
+    onChange,
+    textAreaProps,
+    value,
+    maxLength,
+    ...textFieldProps
+  } = props;
+
+  const t = useTranslations();
+  const isInvalid = props.isInvalid ?? Boolean(errorKey);
+
+  return (
+    <AriaTextField
+      {...textFieldProps}
+      aria-label={ariaLabel}
+      value={value}
+      onChange={onChange}
+      maxLength={maxLength}
+      isInvalid={isInvalid}
+      className={textAreaFieldStyles.root}
+    >
+      <TextArea {...textAreaProps} className={textAreaFieldStyles.input} />
+
+      {maxLength !== undefined && (
+        <Text
+          slot="description"
+          className={textAreaFieldStyles.counter}
+          aria-live="polite"
+          aria-label={t('TextAreaField.counter', {
+            current: value.length,
+            max: maxLength,
+          })}
+        >
+          {`${value.length}/${maxLength}`}
+        </Text>
+      )}
+
+      {errorKey && <FieldError className={textAreaFieldStyles.error}>{t(errorKey)}</FieldError>}
+    </AriaTextField>
+  );
+}

--- a/containers/frontend/web/src/components/controls/text-area/index.ts
+++ b/containers/frontend/web/src/components/controls/text-area/index.ts
@@ -1,0 +1,2 @@
+export { TextArea } from './text-area';
+export type { TextAreaProps } from './text-area';

--- a/containers/frontend/web/src/components/controls/text-area/text-area.styles.ts
+++ b/containers/frontend/web/src/components/controls/text-area/text-area.styles.ts
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/styles/cn';
+
+const textAreaBase = [
+  'font-body-sm',
+  'w-full px-2 py-2 min-h-6 max-h-[160px]',
+  'border border-gray-300 rounded-md',
+  'bg-white',
+  'outline-none transition resize-none',
+];
+
+const textAreaRacStates = [
+  'data-[focus-visible]:ring-2 data-[focus-visible]:ring-offset-2 data-[focus-visible]:ring-blue-500',
+  'data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed',
+  'data-[invalid]:border-red-500',
+  'data-[focused]:bg-white data-[focused]:border-black',
+  'data-[hovered]:border-black',
+];
+
+export function textAreaStyles(className?: string) {
+  return cn(textAreaBase, textAreaRacStates, className);
+}

--- a/containers/frontend/web/src/components/controls/text-area/text-area.tsx
+++ b/containers/frontend/web/src/components/controls/text-area/text-area.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import type { InputEventHandler } from 'react';
+
+import type { TextAreaProps as AriaTextAreaProps } from 'react-aria-components';
+import { TextArea as AriaTextArea } from 'react-aria-components';
+import { textAreaStyles } from './text-area.styles';
+
+export type TextAreaProps = Omit<AriaTextAreaProps, 'size' | 'style' | 'onKeyDown' | 'onInput'> & {
+  className?: string;
+};
+
+const handleInput: InputEventHandler<HTMLTextAreaElement> = (e) => {
+  const el = e.currentTarget;
+
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight + 4}px`;
+};
+
+export function TextArea(props: TextAreaProps) {
+  return (
+    <AriaTextArea {...props} onInput={handleInput} className={textAreaStyles(props.className)} />
+  );
+}

--- a/containers/socket/app/scripts/test.ts
+++ b/containers/socket/app/scripts/test.ts
@@ -1,0 +1,37 @@
+// TO TEST ON BROWSER
+
+// First
+const script = document.createElement('script');
+script.src = 'https://cdn.socket.io/4.8.1/socket.io.min.js';
+document.head.appendChild(script);
+
+// Second
+const socket = io('http://localhost:3100/chat', {
+  path: '/socket.io',
+  transports: ['websocket'],
+});
+
+socket.on('connect', () => {
+  console.log('connected', socket.id);
+  socket.emit('chat:send', { text: 'hello from browser' });
+});
+
+socket.on('chat:message', (msg) => {
+  console.log('message:', msg.content.text);
+});
+
+socket.on('connect_error', (err) => {
+  console.error('connect_error:', err.message);
+});
+
+socket.on('chat:error', (err) => {
+  console.error('chat:error:', err.code, err.details);
+});
+
+socket.on('chat:system', (msg) => {
+  console.log('system message:', msg.type);
+});
+
+socket.emit('chat:send', {
+  text: 'hello world',
+});


### PR DESCRIPTION
This pull request introduces a new chat message validation schema on the backend, a fully featured and accessible `TextAreaField` component on the frontend, and related styling and utility changes. It also adds a browser test script for the chat socket. The main themes are chat schema/validation, frontend text area components, and developer tooling for sockets.

**Chat schema and validation:**
- Added `chat.schema.ts` with Zod-based schemas for chat message validation, error handling, and message history, providing strong typing and validation for both client-to-server and server-to-client chat messages.

**Frontend text area component:**
- Introduced a reusable, accessible `TextAreaField` component with error display, character counter, and internationalization support, along with supporting style modules and exports. [[1]](diffhunk://#diff-b43489ba161f890cee8d4c6ae4006d99a3b46c6d0f5a13a9140ebb0fe1262ddfR1-R65) [[2]](diffhunk://#diff-1741b5065759fa980c09e040e2a2218c7c29e2c31560fe4ed9df87351de86928R1-R2) [[3]](diffhunk://#diff-38c1bd3f159faf83033341c2ba0e2443ff51a35d60b9258c3ac927a87fc35c1aR1-R7)
- Added a new page (`page.tsx`) demonstrating the `TextAreaField` component, including state handling and max length enforcement. ([containers/frontend/web/src/app/[locale]/(public)/ui/text-area/page.tsxR1-R18](diffhunk://#diff-5f86cc2e58e827101eb914c857e54545c295bc4298a3fdc6127246aa4bb09fd3R1-R18))
- Created a lower-level `TextArea` control with auto-resizing and style utilities, and exported it for use in composite components. [[1]](diffhunk://#diff-e64a6e32b8ea7410c90da97a55b3d85fc3fa163815886ac8f8f61f22109bfbbbR1-R24) [[2]](diffhunk://#diff-1ffbc987034861ffd5a25a043b24612aaff4bad620ad6c73d29008395c82e9e7R1-R2) [[3]](diffhunk://#diff-6d4f84259a6f6119961c191c882a1360033ae7af7800bbdd14f59745d4e0b9b7R1-R21)

**Developer tooling:**
- Added a browser test script to easily test chat socket connections and message flows using Socket.IO from the browser console.