### PR TITLE
FIX [#188] Navigation overlay rest of page

### DIFF
--- a/containers/frontend/web/src/features/navigation/navigation.client.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation.client.tsx
@@ -102,7 +102,7 @@ function DesktopNavigation(args: NavigationClientProps) {
 
   return (
     <NavigationProvider value={value}>
-      <div className="absolute inset-0">
+      <div className="absolute inset-0 pointer-events-none">
         <Stack
           as="nav"
           aria-label="main"
@@ -110,7 +110,7 @@ function DesktopNavigation(args: NavigationClientProps) {
             intensity: 'medium',
             blur: 'sm',
             className:
-              'group py-4 z-10 h-screen overflow-y-auto w-min px-0 sticky top-0 rounded-s-none rounded-e-md',
+              'group py-4 z-10 h-screen overflow-y-auto w-min px-0 sticky top-0 rounded-s-none rounded-e-md pointer-events-auto',
           })}
           align="start"
         >


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `DesktopNavigation` component. The change ensures that the navigation container itself does not intercept pointer events, except for the navigation stack, which remains interactive.

- UI/UX Improvements:
  * In `navigation.client.tsx`, added `pointer-events-none` to the outer navigation container and `pointer-events-auto` to the navigation stack to prevent unwanted pointer event interception by the container while keeping the navigation interactive.