### PR TITLE
79 auth fe froms

### DIFF
--- a/containers/frontend/web/src/components/composites/text-field/text-field.tsx
+++ b/containers/frontend/web/src/components/composites/text-field/text-field.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { Ref } from 'react';
 import { FieldError, Label, Text, TextField as AriaTextField } from 'react-aria-components';
 import type { TextFieldProps as AriaTextFieldProps } from 'react-aria-components';
 
@@ -16,6 +17,7 @@ export type TextFieldProps = Omit<AriaTextFieldProps, 'children' | 'className'> 
   descriptionKey?: I18nKey;
   errorKey?: I18nKey;
   inputProps?: InputProps;
+  inputRef?: Ref<HTMLInputElement>;
 };
 
 export function TextField({
@@ -23,6 +25,7 @@ export function TextField({
   descriptionKey,
   errorKey,
   inputProps,
+  inputRef,
   ...props
 }: TextFieldProps) {
   const isInvalid = props.isInvalid ?? Boolean(errorKey);
@@ -30,7 +33,7 @@ export function TextField({
   return (
     <AriaTextField {...props} className={textFieldStyles.root()} isInvalid={isInvalid}>
       <Label className={textFieldStyles.label()}>{t(labelKey)}</Label>
-      <Input {...inputProps} />
+      <Input {...inputProps} ref={inputRef} />
       {descriptionKey && (
         <Text slot="description" className={textFieldStyles.description()}>
           {t(descriptionKey)}

--- a/containers/frontend/web/src/components/controls/input/input.tsx
+++ b/containers/frontend/web/src/components/controls/input/input.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { Ref, KeyboardEventHandler } from 'react';
 import type { InputProps as AriaInputProps } from 'react-aria-components';
 import { Input as AriaInput } from 'react-aria-components';
 
@@ -9,6 +10,8 @@ import type { InputSize as Size, InputVariant as Variant } from './input.styles'
 export type InputProps = Omit<AriaInputProps, 'className' | 'size' | 'style' | 'onKeyDown'> & {
   variant?: Variant;
   size?: Size;
+  ref?: Ref<HTMLInputElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 };
 
 export function Input({ variant = 'default', size = 'md', ...props }: InputProps) {

--- a/containers/frontend/web/src/components/controls/input/input.tsx
+++ b/containers/frontend/web/src/components/controls/input/input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { forwardRef, Ref } from 'react';
+import { forwardRef, type Ref } from 'react';
 import type { InputProps as AriaInputProps } from 'react-aria-components';
 import { Input as AriaInput } from 'react-aria-components';
 

--- a/containers/frontend/web/src/components/controls/input/input.tsx
+++ b/containers/frontend/web/src/components/controls/input/input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Ref } from 'react';
+import type { forwardRef, Ref } from 'react';
 import type { InputProps as AriaInputProps } from 'react-aria-components';
 import { Input as AriaInput } from 'react-aria-components';
 
@@ -13,6 +13,9 @@ export type InputProps = Omit<AriaInputProps, 'className' | 'size' | 'style' | '
   ref?: Ref<HTMLInputElement>;
 };
 
-export function Input({ variant = 'default', size = 'md', ...props }: InputProps) {
-  return <AriaInput {...props} className={() => inputStyles({ variant, size })} />;
-}
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { variant = 'default', size = 'md', ...props },
+  ref,
+) {
+  return <AriaInput {...props} ref={ref} className={() => inputStyles({ variant, size })} />;
+});

--- a/containers/frontend/web/src/components/controls/input/input.tsx
+++ b/containers/frontend/web/src/components/controls/input/input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Ref, KeyboardEventHandler } from 'react';
+import type { Ref } from 'react';
 import type { InputProps as AriaInputProps } from 'react-aria-components';
 import { Input as AriaInput } from 'react-aria-components';
 
@@ -11,7 +11,6 @@ export type InputProps = Omit<AriaInputProps, 'className' | 'size' | 'style' | '
   variant?: Variant;
   size?: Size;
   ref?: Ref<HTMLInputElement>;
-  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 };
 
 export function Input({ variant = 'default', size = 'md', ...props }: InputProps) {

--- a/containers/frontend/web/src/features/auth/create-account/create-account.form.tsx
+++ b/containers/frontend/web/src/features/auth/create-account/create-account.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState, useEffect, useRef, type KeyboardEvent } from 'react';
+import { useActionState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { useForm } from '@/lib/forms/use-form';
@@ -29,20 +29,12 @@ type StateActionProps = {
 
 function useCreateAccountFieldNavigation() {
   const emailRef = useRef<HTMLInputElement | null>(null);
-  const passwordRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     emailRef.current?.focus();
   }, []);
 
-  function handleEmailEnter(e: KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      passwordRef.current?.focus();
-    }
-  }
-
-  return { emailRef, passwordRef, handleEmailEnter };
+  return { emailRef };
 }
 
 // TODO make a component
@@ -59,7 +51,7 @@ export function CreateAccountForm() {
   const form = useForm<SignupReq>(formApiReq);
   const t = useTranslations('auth');
   const [state, formAction] = useActionState(signupAction, null);
-  const { emailRef, passwordRef, handleEmailEnter } = useCreateAccountFieldNavigation();
+  const { emailRef } = useCreateAccountFieldNavigation();
 
   return (
     <>
@@ -76,7 +68,7 @@ export function CreateAccountForm() {
           errorKey={form.errors.email && `validation.${form.errors.email}`}
           onChange={(v) => form.setValue('email', v)}
           onBlur={() => form.setTouch('email')}
-          inputProps={{ ref: emailRef, onKeyDown: handleEmailEnter }}
+          inputProps={{ ref: emailRef }}
           {...fieldsBase.email}
         />
         <TextField
@@ -84,7 +76,6 @@ export function CreateAccountForm() {
           errorKey={form.errors.password && `validation.${form.errors.password}`}
           onChange={(v) => form.setValue('password', v)}
           onBlur={() => form.setTouch('password')}
-          inputProps={{ ref: passwordRef }}
           {...fieldsBase.password}
         />
         <Button type="submit">{t('createAccount.submit')}</Button>

--- a/containers/frontend/web/src/features/auth/create-account/create-account.form.tsx
+++ b/containers/frontend/web/src/features/auth/create-account/create-account.form.tsx
@@ -68,7 +68,7 @@ export function CreateAccountForm() {
           errorKey={form.errors.email && `validation.${form.errors.email}`}
           onChange={(v) => form.setValue('email', v)}
           onBlur={() => form.setTouch('email')}
-          inputProps={{ ref: emailRef }}
+          inputRef={emailRef}
           {...fieldsBase.email}
         />
         <TextField

--- a/containers/frontend/web/src/features/auth/create-account/create-account.form.tsx
+++ b/containers/frontend/web/src/features/auth/create-account/create-account.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState } from 'react';
+import { useActionState, useEffect, useRef, type KeyboardEvent } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { useForm } from '@/lib/forms/use-form';
@@ -27,6 +27,24 @@ type StateActionProps = {
     | undefined;
 };
 
+function useCreateAccountFieldNavigation() {
+  const emailRef = useRef<HTMLInputElement | null>(null);
+  const passwordRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
+
+  function handleEmailEnter(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      passwordRef.current?.focus();
+    }
+  }
+
+  return { emailRef, passwordRef, handleEmailEnter };
+}
+
 // TODO make a component
 function APIError({ state }: StateActionProps) {
   const t2 = useTranslations('api');
@@ -41,6 +59,8 @@ export function CreateAccountForm() {
   const form = useForm<SignupReq>(formApiReq);
   const t = useTranslations('auth');
   const [state, formAction] = useActionState(signupAction, null);
+  const { emailRef, passwordRef, handleEmailEnter } = useCreateAccountFieldNavigation();
+
   return (
     <>
       <APIError state={state} />
@@ -56,6 +76,7 @@ export function CreateAccountForm() {
           errorKey={form.errors.email && `validation.${form.errors.email}`}
           onChange={(v) => form.setValue('email', v)}
           onBlur={() => form.setTouch('email')}
+          inputProps={{ ref: emailRef, onKeyDown: handleEmailEnter }}
           {...fieldsBase.email}
         />
         <TextField
@@ -63,6 +84,7 @@ export function CreateAccountForm() {
           errorKey={form.errors.password && `validation.${form.errors.password}`}
           onChange={(v) => form.setValue('password', v)}
           onBlur={() => form.setTouch('password')}
+          inputProps={{ ref: passwordRef }}
           {...fieldsBase.password}
         />
         <Button type="submit">{t('createAccount.submit')}</Button>

--- a/containers/frontend/web/src/features/auth/login/login.form.tsx
+++ b/containers/frontend/web/src/features/auth/login/login.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState, useEffect, useRef, type KeyboardEvent } from 'react';
+import { useActionState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { InternalLink } from '@components/controls/link/link';
@@ -30,23 +30,13 @@ function APIError({ err }: StateActionProps) {
 
 function useLoginFieldNavigation() {
   const identifierRef = useRef<HTMLInputElement | null>(null);
-  const passwordRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     identifierRef.current?.focus();
   }, []);
 
-  function handleIdentifierEnter(e: KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      passwordRef.current?.focus();
-    }
-  }
-
   return {
     identifierRef,
-    passwordRef,
-    handleIdentifierEnter,
   };
 }
 
@@ -55,7 +45,7 @@ export function LoginForm() {
   const form = useForm<LoginReq>(formApiReq);
   const [state, formAction] = useActionState(loginAction, null);
 
-  const { identifierRef, passwordRef, handleIdentifierEnter } = useLoginFieldNavigation();
+  const { identifierRef } = useLoginFieldNavigation();
 
   return (
     <>
@@ -73,7 +63,7 @@ export function LoginForm() {
           errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}
           onChange={(v) => form.setValue('identifier', v)}
           onBlur={() => form.setTouch('identifier')}
-          inputProps={{ ref: identifierRef, onKeyDown: handleIdentifierEnter }}
+          inputProps={{ ref: identifierRef }}
           {...fieldsBase.identifier}
         />
 
@@ -82,7 +72,6 @@ export function LoginForm() {
           errorKey={form.errors.password && `validation.${form.errors.password}`}
           onChange={(v) => form.setValue('password', v)}
           onBlur={() => form.setTouch('password')}
-          inputProps={{ ref: passwordRef }}
           {...fieldsBase.password}
         />
 

--- a/containers/frontend/web/src/features/auth/login/login.form.tsx
+++ b/containers/frontend/web/src/features/auth/login/login.form.tsx
@@ -63,7 +63,7 @@ export function LoginForm() {
           errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}
           onChange={(v) => form.setValue('identifier', v)}
           onBlur={() => form.setTouch('identifier')}
-          inputProps={{ ref: identifierRef }}
+          inputRef={identifierRef}
           {...fieldsBase.identifier}
         />
 

--- a/containers/frontend/web/src/features/auth/login/login.form.tsx
+++ b/containers/frontend/web/src/features/auth/login/login.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState } from 'react';
+import { useActionState, useEffect, useRef, type KeyboardEvent } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { InternalLink } from '@components/controls/link/link';
@@ -19,8 +19,6 @@ type StateActionProps = {
   err: ApiResponse<LoginRes> | null | undefined;
 };
 
-// TODO make a component
-// TODO Add all error codes form auth to i18n
 function APIError({ err }: StateActionProps) {
   const t = useTranslations('api');
   return err?.ok === false ? (
@@ -30,14 +28,39 @@ function APIError({ err }: StateActionProps) {
   ) : null;
 }
 
+function useLoginFieldNavigation() {
+  const identifierRef = useRef<HTMLInputElement | null>(null);
+  const passwordRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    identifierRef.current?.focus();
+  }, []);
+
+  function handleIdentifierEnter(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      passwordRef.current?.focus();
+    }
+  }
+
+  return {
+    identifierRef,
+    passwordRef,
+    handleIdentifierEnter,
+  };
+}
+
 export function LoginForm() {
   const t = useTranslations('auth');
   const form = useForm<LoginReq>(formApiReq);
   const [state, formAction] = useActionState(loginAction, null);
 
+  const { identifierRef, passwordRef, handleIdentifierEnter } = useLoginFieldNavigation();
+
   return (
     <>
-      {state?.ok === false ? <APIError err={state} /> : null}
+      {state?.ok === false && <APIError err={state} />}
+
       <Form
         action={formAction}
         onSubmit={(e) => {
@@ -50,6 +73,7 @@ export function LoginForm() {
           errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}
           onChange={(v) => form.setValue('identifier', v)}
           onBlur={() => form.setTouch('identifier')}
+          inputProps={{ ref: identifierRef, onKeyDown: handleIdentifierEnter }}
           {...fieldsBase.identifier}
         />
 
@@ -58,11 +82,14 @@ export function LoginForm() {
           errorKey={form.errors.password && `validation.${form.errors.password}`}
           onChange={(v) => form.setValue('password', v)}
           onBlur={() => form.setTouch('password')}
+          inputProps={{ ref: passwordRef }}
           {...fieldsBase.password}
         />
-        <div className="flex row gap-2  justify-center">
-          <InternalLink href={'/recover'}>{t('login.forgotPassword')}</InternalLink>
+
+        <div className="flex gap-2 justify-center">
+          <InternalLink href="/recover">{t('login.forgotPassword')}</InternalLink>
         </div>
+
         <Button type="submit">{t('login.submit')}</Button>
       </Form>
     </>

--- a/containers/frontend/web/src/features/auth/recover/recover.tsx
+++ b/containers/frontend/web/src/features/auth/recover/recover.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useRef, type KeyboardEvent } from 'react';
+
 import { Form } from '@components/composites/form';
 import { TextField } from '@components/composites/text-field';
 import { Button } from '@components/controls/button';
@@ -31,9 +33,31 @@ const formApiReq = {
   defaultValues,
 } as const;
 
+function useRecoverFieldNavigation() {
+  const identifierRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    identifierRef.current?.focus();
+  }, []);
+
+  function handleIdentifierEnter(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  }
+
+  return {
+    identifierRef,
+    handleIdentifierEnter,
+  };
+}
+
 export function RecoverFeature() {
   const form = useForm<RecoverReq>(formApiReq);
   const t = useTranslations('auth');
+
+  const { identifierRef, handleIdentifierEnter } = useRecoverFieldNavigation();
+
   return (
     <Stack justify="center">
       <Text as="h1" variant="heading-md">
@@ -52,6 +76,7 @@ export function RecoverFeature() {
           errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}
           onChange={(v) => form.setValue('identifier', v)}
           onBlur={() => form.setTouch('identifier')}
+          inputProps={{ ref: identifierRef, onKeyDown: handleIdentifierEnter }}
           {...fieldsBase.identifier}
         />
 

--- a/containers/frontend/web/src/features/auth/recover/recover.tsx
+++ b/containers/frontend/web/src/features/auth/recover/recover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, type KeyboardEvent } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Form } from '@components/composites/form';
 import { TextField } from '@components/composites/text-field';
@@ -40,15 +40,8 @@ function useRecoverFieldNavigation() {
     identifierRef.current?.focus();
   }, []);
 
-  function handleIdentifierEnter(e: KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-    }
-  }
-
   return {
     identifierRef,
-    handleIdentifierEnter,
   };
 }
 
@@ -56,7 +49,7 @@ export function RecoverFeature() {
   const form = useForm<RecoverReq>(formApiReq);
   const t = useTranslations('auth');
 
-  const { identifierRef, handleIdentifierEnter } = useRecoverFieldNavigation();
+  const { identifierRef } = useRecoverFieldNavigation();
 
   return (
     <Stack justify="center">
@@ -76,7 +69,7 @@ export function RecoverFeature() {
           errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}
           onChange={(v) => form.setValue('identifier', v)}
           onBlur={() => form.setTouch('identifier')}
-          inputProps={{ ref: identifierRef, onKeyDown: handleIdentifierEnter }}
+          inputProps={{ ref: identifierRef }}
           {...fieldsBase.identifier}
         />
 

--- a/containers/frontend/web/src/features/auth/recover/recover.tsx
+++ b/containers/frontend/web/src/features/auth/recover/recover.tsx
@@ -69,7 +69,7 @@ export function RecoverFeature() {
           errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}
           onChange={(v) => form.setValue('identifier', v)}
           onBlur={() => form.setTouch('identifier')}
-          inputProps={{ ref: identifierRef }}
+          inputRef={identifierRef}
           {...fieldsBase.identifier}
         />
 

--- a/containers/frontend/web/src/lib/forms/use-form.ts
+++ b/containers/frontend/web/src/lib/forms/use-form.ts
@@ -31,8 +31,15 @@ export function useForm<T extends Record<string, unknown>>(args: UseFormProps<T>
   const [errors, setErrors] = useState<FieldErrorsOf<T>>(() => ({}));
 
   const setValue = useCallback(
-    <K extends keyof T>(name: K, value: T[K]) => setValues((p) => ({ ...p, [name]: value })),
-    [],
+    <K extends keyof T>(name: K, value: T[K]) =>
+      setValues((prev) => {
+        const nextValues = { ...prev, [name]: value };
+
+        if (touched[name]) setErrors(validate(schema, nextValues, touched, fieldNames).errors);
+
+        return nextValues;
+      }),
+    [schema, touched, fieldNames],
   );
 
   const setTouch = useCallback(

--- a/containers/frontend/web/src/lib/forms/use-form.ts
+++ b/containers/frontend/web/src/lib/forms/use-form.ts
@@ -5,12 +5,16 @@ import { useState, useCallback, useMemo } from 'react';
 import { validate, validateAll } from './validation';
 import type { z } from 'zod';
 
+type DirtyOf<T> = Partial<Record<keyof T, true>>;
+
 type FormApi<T extends Record<string, unknown>> = {
   values: T;
   setValue: <K extends keyof T>(name: K, value: T[K]) => void;
 
   touched: TouchedOf<T>;
   setTouch: <K extends keyof T>(name: K) => void;
+
+  dirty: DirtyOf<T>;
 
   errors: Partial<Record<keyof T, string>>;
 
@@ -28,14 +32,19 @@ export function useForm<T extends Record<string, unknown>>(args: UseFormProps<T>
 
   const [values, setValues] = useState<T>(() => defaultValues);
   const [touched, setTouched] = useState<TouchedOf<T>>(() => ({}));
+  const [dirty, setDirty] = useState<DirtyOf<T>>(() => ({}));
   const [errors, setErrors] = useState<FieldErrorsOf<T>>(() => ({}));
 
   const setValue = useCallback(
     <K extends keyof T>(name: K, value: T[K]) =>
-      setValues((prev) => {
-        const nextValues = { ...prev, [name]: value };
+      setValues((prevValues) => {
+        const nextValues = { ...prevValues, [name]: value };
 
-        if (touched[name]) setErrors(validate(schema, nextValues, touched, fieldNames).errors);
+        setDirty((prevDirty) => ({ ...prevDirty, [name]: true }));
+
+        if (touched[name]) {
+          setErrors(validate(schema, nextValues, touched, fieldNames).errors);
+        }
 
         return nextValues;
       }),
@@ -43,13 +52,16 @@ export function useForm<T extends Record<string, unknown>>(args: UseFormProps<T>
   );
 
   const setTouch = useCallback(
-    <K extends keyof T>(name: K) =>
-      setTouched((p) => {
-        const next = { ...p, [name]: true };
-        setErrors(validate(schema, values, next, fieldNames).errors);
-        return next;
-      }),
-    [schema, values, fieldNames],
+    <K extends keyof T>(name: K) => {
+      if (!dirty[name]) return;
+
+      setTouched((prevTouched) => {
+        const nextTouched = { ...prevTouched, [name]: true };
+        setErrors(validate(schema, values, nextTouched, fieldNames).errors);
+        return nextTouched;
+      });
+    },
+    [dirty, schema, values, fieldNames],
   );
 
   const validateBeforeSubmit = useCallback(() => {
@@ -60,7 +72,7 @@ export function useForm<T extends Record<string, unknown>>(args: UseFormProps<T>
   }, [schema, values, fieldNames]);
 
   return useMemo(
-    () => ({ values, setValue, touched, setTouch, errors, validateBeforeSubmit }),
-    [values, setValue, touched, setTouch, errors, validateBeforeSubmit],
+    () => ({ values, setValue, touched, setTouch, dirty, errors, validateBeforeSubmit }),
+    [values, setValue, touched, setTouch, dirty, errors, validateBeforeSubmit],
   );
 }


### PR DESCRIPTION
The input with the default behavior was working as intended; the issue was with validation.

Current behavior:
- The first field of the form is focused on load.
- On mobile, when the field is valid and Enter is pressed, it moves to the next field or submits the form.

Tested forms:
- Login
- Create account
- Recover account

Tested in:
- Spanish
- English

This pull request improves the accessibility and user experience of authentication forms by ensuring the first input field is automatically focused when the form loads. It also enhances the flexibility of the `Input` and `TextField` components by supporting refs, and refines form validation error handling.

**Accessibility and User Experience Improvements:**

* Added custom hooks (`useCreateAccountFieldNavigation`, `useLoginFieldNavigation`, `useRecoverFieldNavigation`) to automatically focus the primary input field on mount in the create account, login, and password recovery forms, respectively. [[1]](diffhunk://#diff-82e9f0182170a4ac511ef4824c0b90f82712eab01d7a90e49fdbf5b1376f614eR30-R39) [[2]](diffhunk://#diff-82e9f0182170a4ac511ef4824c0b90f82712eab01d7a90e49fdbf5b1376f614eR54-R55) [[3]](diffhunk://#diff-82e9f0182170a4ac511ef4824c0b90f82712eab01d7a90e49fdbf5b1376f614eR71) [[4]](diffhunk://#diff-7f8de2d8212695aa90421beea1bc822b5b711f9325830216e3f8aa04250f2480L3-R3) [[5]](diffhunk://#diff-7f8de2d8212695aa90421beea1bc822b5b711f9325830216e3f8aa04250f2480L22-L23) [[6]](diffhunk://#diff-7f8de2d8212695aa90421beea1bc822b5b711f9325830216e3f8aa04250f2480R31-R53) [[7]](diffhunk://#diff-7f8de2d8212695aa90421beea1bc822b5b711f9325830216e3f8aa04250f2480R66) [[8]](diffhunk://#diff-7792ec4e60bf954b1f5e94e2932caaea7f9f8688c3dc7ecb7b4edb4bcfdf4202R3-R4) [[9]](diffhunk://#diff-7792ec4e60bf954b1f5e94e2932caaea7f9f8688c3dc7ecb7b4edb4bcfdf4202R36-R53) [[10]](diffhunk://#diff-7792ec4e60bf954b1f5e94e2932caaea7f9f8688c3dc7ecb7b4edb4bcfdf4202R72)

**Component API Enhancements:**

* Updated the `Input` component to use `forwardRef`, allowing refs to be passed and used for focus management and other direct DOM access. [[1]](diffhunk://#diff-af59651919e963e7a5a75e263c0f37eb12ae5bcaac27331d97784d29cb1072dfR3) [[2]](diffhunk://#diff-af59651919e963e7a5a75e263c0f37eb12ae5bcaac27331d97784d29cb1072dfR13-R21)
* Modified the `TextField` component to accept an `inputRef` prop, which is forwarded to the underlying input element, enabling parent components to control focus. [[1]](diffhunk://#diff-a6db09d4425e69d95dc4f42fe74a2156214cf3c9233bade6b2abe3f369821d38R3) [[2]](diffhunk://#diff-a6db09d4425e69d95dc4f42fe74a2156214cf3c9233bade6b2abe3f369821d38R20-R36)

**Form Validation Improvements:**

* Enhanced the `useForm` hook so that updating a field value also updates validation errors in real-time if the field has been touched, providing immediate feedback to users.

**Minor UI Cleanup:**

* Fixed class names and simplified conditional rendering in the login form for better readability and consistency.