### PR TITLE
STYLES refactor: extract glass card styles into separate functions fo…

### DIFF
--- a/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
+++ b/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
@@ -1,5 +1,8 @@
 import { cn } from '@/lib/styles/cn';
-import { glassCardStyles } from '@components/primitives/glass-card/glass-card.styles';
+import {
+  glassBackgroundStyles,
+  glassBorderStyles,
+} from '@components/primitives/glass-card/glass-card.styles';
 
 const groupBase = ['inline-flex'];
 
@@ -30,7 +33,12 @@ const labelBase = 'relative z-10';
 export const segmentedControlGroupStyles = {
   group: () => cn(groupBase),
   item: () =>
-    cn(glassCardStyles({ blur: 'sm', intensity: 'low', border: 'low' }), itemBase, itemRACState),
+    cn(
+      glassBackgroundStyles({ blur: 'sm', intensity: 'low' }),
+      glassBorderStyles({ border: 'low' }),
+      itemBase,
+      itemRACState,
+    ),
   indicator: () => cn(indicatorBase, indicatorRACState),
   label: () => cn(labelBase),
 };

--- a/containers/frontend/web/src/components/primitives/glass-card/glass-card.styles.ts
+++ b/containers/frontend/web/src/components/primitives/glass-card/glass-card.styles.ts
@@ -26,27 +26,43 @@ const border = {
   high: 'border border-white/[0.40] dark:border-white/[0.15]',
 } as const;
 
+const cardLayout = [
+  'shadow-[0_8px_32px_0_rgba(0,0,0,0.08)]',
+  'rounded-3xl p-8',
+  'transition-all duration-300',
+];
+
 export type GlassBlur = keyof typeof blur;
 export type GlassIntensity = keyof typeof intensity;
 export type GlassBorder = keyof typeof border;
 
-type GlassStylesOpts = {
+export type GlassBackgroundStylesOpts = {
   blur?: GlassBlur;
   intensity?: GlassIntensity;
-  border?: GlassBorder;
   saturate?: boolean;
-  className?: string;
 };
 
-export function glassCardStyles(opts: GlassStylesOpts = {}) {
+export type GlassBorderStylesOpts = {
+  border?: GlassBorder;
+};
+
+export type GlassCardStylesOpts = GlassBackgroundStylesOpts &
+  GlassBorderStylesOpts & {
+    className?: string;
+  };
+
+export function glassBackgroundStyles(opts: GlassBackgroundStylesOpts = {}) {
   return cn(
     blur[opts.blur ?? 'sm2'],
     intensity[opts.intensity ?? 'medium'],
     opts.saturate !== false && 'backdrop-saturate-[150%]',
-    border[opts.border ?? 'medium'],
-    'shadow-[0_8px_32px_0_rgba(0,0,0,0.08)]',
-    'rounded-3xl p-8',
-    'transition-all duration-300',
-    opts.className,
   );
+}
+
+export function glassBorderStyles(opts: GlassBorderStylesOpts = {}) {
+  return cn(border[opts.border ?? 'medium']);
+}
+
+export function glassCardStyles(opts: GlassCardStylesOpts = {}) {
+  return cn(glassBackgroundStyles(opts), glassBorderStyles(opts), cardLayout, opts.className);
 }


### PR DESCRIPTION
This pull request refactors the glass card styling utilities to improve modularity and flexibility. The main changes involve splitting the glass card styles into separate background and border style functions, updating their usage in the segmented control group, and enhancing type safety with new options types.

**Styling utilities refactor:**

* Split `glassCardStyles` into three composable functions: `glassBackgroundStyles`, `glassBorderStyles`, and a new `glassCardStyles` that composes both and adds layout styles. This allows for more granular control over glass card styling.
* Added new types: `GlassBackgroundStylesOpts`, `GlassBorderStylesOpts`, and `GlassCardStylesOpts` for improved type safety and clarity when applying styles.

**Component usage update:**

* Updated `segmented-control-group.styles.ts` to use `glassBackgroundStyles` and `glassBorderStyles` separately instead of the previous `glassCardStyles`, aligning with the new modular styling approach. [[1]](diffhunk://#diff-746a003aba3acf9effdab2cdba8467befd33f0bd94d2650d8294fa6ba6b7c39bL2-R5) [[2]](diffhunk://#diff-746a003aba3acf9effdab2cdba8467befd33f0bd94d2650d8294fa6ba6b7c39bL33-R41)
[Copilot is generating a summary...]