### PR TITLE
add localized routing paths for the game page

### DIFF
--- a/containers/frontend/web/src/i18n/routing.ts
+++ b/containers/frontend/web/src/i18n/routing.ts
@@ -63,6 +63,11 @@ export const routing = defineRouting({
       es: '/terminos',
       ca: '/termes',
     },
+    '/game': {
+      en: '/game',
+      es: '/juego',
+      ca: '/joc',
+    },
   },
   localeCookie,
 });


### PR DESCRIPTION
This pull request adds a new localized route for the `/game` path to the application's routing configuration. The route is now available in English, Spanish, and Catalan.

- Added a `/game` route with localized paths: `/game` (English), `/juego` (Spanish), and `/joc` (Catalan) in `routing.ts`.