### PR TITLE
238 fe dark light mode for the navigation drawer and chat

### DIFF
--- a/containers/frontend/web/src/app/[locale]/(private)/robots/page.tsx
+++ b/containers/frontend/web/src/app/[locale]/(private)/robots/page.tsx
@@ -14,7 +14,7 @@ type Character = {
 export default function ThreejsPage() {
   const [characters, setCharacters] = useState<Character[]>([]);
   return (
-    <div className="h-full w-full">
+    <div className="min-h-screen w-full">
       <RobotsSocketManager onRobots={setCharacters} />
       <RobotsScene characters={characters} />
     </div>

--- a/containers/frontend/web/src/app/globals.css
+++ b/containers/frontend/web/src/app/globals.css
@@ -84,6 +84,7 @@
 
   /* shadows */
   --shadow-header: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-drawer: 8px 0 20px rgba(0, 0, 0, 0.1);
 }
 
 .dark {
@@ -98,6 +99,7 @@
   --color-grid-line: rgba(255, 255, 255, 0.02); /* Very subtle white for dark mode */
   --shadow-header:
     0 4px 6px -1px rgba(255, 255, 255, 0.12), 0 2px 4px -2px rgba(255, 255, 255, 0.12);
+  --shadow-drawer: 8px 0 20px rgba(255, 255, 255, 0.12);
 }
 
 .font-caption {
@@ -272,4 +274,8 @@ select:-webkit-autofill:hover {
 
 .shadow-header {
   box-shadow: var(--shadow-header);
+}
+
+.shadow-drawer {
+  box-shadow: var(--shadow-drawer);
 }

--- a/containers/frontend/web/src/app/globals.css
+++ b/containers/frontend/web/src/app/globals.css
@@ -82,7 +82,8 @@
   --space-lg: var(--space-5);
   --space-xl: var(--space-7);
 
-  --color-shadow: rgba(0, 0, 0, 0.168);
+  --color-shadow-rgb: 0, 0, 0;
+  --color-shadow-opacity: 0.1;
 }
 
 .dark {
@@ -95,7 +96,8 @@
   --color-bg-secondary: #1e293b; /* slate-800 */
   --color-border-primary: #334155; /* slate-700 */
   --color-grid-line: #ffffff05; /* Very subtle white for dark mode */
-  --color-shadow: rgba(255, 255, 255, 0.099);
+  --color-shadow-rgb: 255, 255, 255;
+  --color-shadow-opacity: 0.12;
 }
 
 .font-caption {

--- a/containers/frontend/web/src/app/globals.css
+++ b/containers/frontend/web/src/app/globals.css
@@ -97,7 +97,7 @@
   --color-border-primary: #334155; /* slate-700 */
   --color-grid-line: #ffffff05; /* Very subtle white for dark mode */
   --color-shadow-rgb: 255, 255, 255;
-  --color-shadow-opacity: 0.12;
+  --color-shadow-opacity: 0.1;
 }
 
 .font-caption {
@@ -263,7 +263,7 @@ select:-webkit-autofill:hover {
 
 .fancy-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 25px 45px rgba(var(--color-shadow-rgb), var(--color-shadow-opacity));
 }
 
 .fancy-btn:active {

--- a/containers/frontend/web/src/app/globals.css
+++ b/containers/frontend/web/src/app/globals.css
@@ -81,6 +81,9 @@
   --space-md: var(--space-4);
   --space-lg: var(--space-5);
   --space-xl: var(--space-7);
+
+  /* shadows */
+  --shadow-header: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
 }
 
 .dark {
@@ -93,6 +96,8 @@
   --color-bg-secondary: #1e293b; /* slate-800 */
   --color-border-primary: #334155; /* slate-700 */
   --color-grid-line: rgba(255, 255, 255, 0.02); /* Very subtle white for dark mode */
+  --shadow-header:
+    0 4px 6px -1px rgba(255, 255, 255, 0.12), 0 2px 4px -2px rgba(255, 255, 255, 0.12);
 }
 
 .font-caption {
@@ -263,4 +268,8 @@ select:-webkit-autofill:hover {
 
 .fancy-btn:active {
   transform: translateY(-1px);
+}
+
+.shadow-header {
+  box-shadow: var(--shadow-header);
 }

--- a/containers/frontend/web/src/app/globals.css
+++ b/containers/frontend/web/src/app/globals.css
@@ -82,9 +82,7 @@
   --space-lg: var(--space-5);
   --space-xl: var(--space-7);
 
-  /* shadows */
-  --shadow-header: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-  --shadow-drawer: 8px 0 20px rgba(0, 0, 0, 0.1);
+  --color-shadow: rgba(0, 0, 0, 0.168);
 }
 
 .dark {
@@ -96,10 +94,8 @@
   --color-bg-primary: #020617; /* slate-950 (Dark blue) */
   --color-bg-secondary: #1e293b; /* slate-800 */
   --color-border-primary: #334155; /* slate-700 */
-  --color-grid-line: rgba(255, 255, 255, 0.02); /* Very subtle white for dark mode */
-  --shadow-header:
-    0 4px 6px -1px rgba(255, 255, 255, 0.12), 0 2px 4px -2px rgba(255, 255, 255, 0.12);
-  --shadow-drawer: 8px 0 20px rgba(255, 255, 255, 0.12);
+  --color-grid-line: #ffffff05; /* Very subtle white for dark mode */
+  --color-shadow: rgba(255, 255, 255, 0.099);
 }
 
 .font-caption {
@@ -270,12 +266,4 @@ select:-webkit-autofill:hover {
 
 .fancy-btn:active {
   transform: translateY(-1px);
-}
-
-.shadow-header {
-  box-shadow: var(--shadow-header);
-}
-
-.shadow-drawer {
-  box-shadow: var(--shadow-drawer);
 }

--- a/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
+++ b/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
@@ -20,7 +20,7 @@ const drawerBase = [
   'bg-bg-primary/50 dark:bg-bg-primary/30',
   'backdrop-blur-md',
   'border-r border-border-primary',
-  'shadow-[-8px_0_20px_rgba(0,0,0,0.1)]',
+  'shadow-drawer',
   'transition-transform duration-300',
   'translate-x-0',
   'p-0',

--- a/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
+++ b/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
@@ -3,7 +3,7 @@ import { cn } from '@/lib/styles/cn';
 const overlayBase = [
   'absolute top-0 left-0 w-full z-[100]',
   'h-[var(--page-height)]',
-  'bg-black/30 backdrop-blur-[10px]',
+  'bg-transparent',
 ];
 
 const overlayRacStates = [
@@ -17,12 +17,13 @@ export function drawerOverlayStyles() {
 
 const drawerBase = [
   'fixed left-0 top-0 h-screen',
-  'bg-white',
-  'border-l border-gray-200',
+  'bg-bg-primary/50 dark:bg-bg-primary/30',
+  'backdrop-blur-md',
+  'border-r border-border-primary',
   'shadow-[-8px_0_20px_rgba(0,0,0,0.1)]',
   'transition-transform duration-300',
   'translate-x-0',
-  'p-4',
+  'p-0',
 ];
 
 const drawerRacStates = [

--- a/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
+++ b/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
@@ -22,7 +22,7 @@ const drawerBase = [
 ];
 
 const drawerRacStates = [
-  'data-[enter]:translate-x-0 h-data-[entering]:translate-x-0 data-[entered]:translate-x-0',
+  'data-[enter]:translate-x-0 data-[entering]:translate-x-0 data-[entered]:translate-x-0',
 ];
 
 export function drawerStyles() {

--- a/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
+++ b/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
@@ -16,7 +16,7 @@ const drawerBase = [
   'bg-bg-primary/50 dark:bg-bg-primary/30',
   'backdrop-blur-md',
   'border-r border-border-primary',
-  'shadow-[8px_0_20px_var(--color-shadow)]',
+  'shadow-[8px_0_20px_rgba(var(--color-shadow-rgb),var(--color-shadow-opacity))]',
   'transition-transform duration-300',
   'translate-x-0',
 ];

--- a/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
+++ b/containers/frontend/web/src/components/composites/drawer/drawer.styles.ts
@@ -1,10 +1,6 @@
 import { cn } from '@/lib/styles/cn';
 
-const overlayBase = [
-  'absolute top-0 left-0 w-full z-[100]',
-  'h-[var(--page-height)]',
-  'bg-transparent',
-];
+const overlayBase = ['absolute top-0 left-0 w-full z-[100]', 'h-[var(--page-height)]'];
 
 const overlayRacStates = [
   'data-[entering]:bg-black/30 data-[entering]:backdrop-blur-md',
@@ -16,18 +12,17 @@ export function drawerOverlayStyles() {
 }
 
 const drawerBase = [
-  'fixed left-0 top-0 h-screen',
+  'fixed left-0 top-0 h-screen rounded-lg',
   'bg-bg-primary/50 dark:bg-bg-primary/30',
   'backdrop-blur-md',
   'border-r border-border-primary',
-  'shadow-drawer',
+  'shadow-[8px_0_20px_var(--color-shadow)]',
   'transition-transform duration-300',
   'translate-x-0',
-  'p-0',
 ];
 
 const drawerRacStates = [
-  'data-[enter]:translate-x-0 data-[entering]:translate-x-0 data-[entered]:translate-x-0',
+  'data-[enter]:translate-x-0 h-data-[entering]:translate-x-0 data-[entered]:translate-x-0',
 ];
 
 export function drawerStyles() {

--- a/containers/frontend/web/src/components/composites/drawer/drawer.tsx
+++ b/containers/frontend/web/src/components/composites/drawer/drawer.tsx
@@ -15,7 +15,7 @@ export function Drawer(props: ModalOverlayProps) {
     <ModalOverlay className={drawerOverlayStyles()}>
       {composeRenderProps(props.children, (children) => (
         <Modal className={drawerStyles()} isOpen={true}>
-          <Dialog>{children}</Dialog>
+          <Dialog className="h-full">{children}</Dialog>
         </Modal>
       ))}
     </ModalOverlay>

--- a/containers/frontend/web/src/components/composites/form/form.styles.ts
+++ b/containers/frontend/web/src/components/composites/form/form.styles.ts
@@ -2,6 +2,6 @@ import { cn } from '@/lib/styles/cn';
 
 const formBase = 'flex flex-col gap-4 min-w-[320px]';
 
-export function formStyles() {
-  return cn(formBase);
+export function formStyles(className?: string) {
+  return cn(formBase, className);
 }

--- a/containers/frontend/web/src/components/composites/form/form.tsx
+++ b/containers/frontend/web/src/components/composites/form/form.tsx
@@ -11,6 +11,6 @@ export type FormProps = Omit<FormHTMLAttributes<HTMLFormElement>, 'action' | 'me
   method?: 'GET' | 'POST';
 };
 
-export function Form({ action, method, ...props }: FormProps) {
-  return <form {...props} action={action} method={method} className={formStyles()} />;
+export function Form({ action, method, className, ...props }: FormProps) {
+  return <form {...props} action={action} method={method} className={formStyles(className)} />;
 }

--- a/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
+++ b/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
@@ -1,6 +1,4 @@
 import { cn } from '@/lib/styles/cn';
-import { glassBackgroundStyles, glassBorderStyles } from '@components';
-import { InteractiveControlSize } from '@components/primitives/interactive-control';
 
 const groupBase = ['inline-flex'];
 

--- a/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
+++ b/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.styles.ts
@@ -1,41 +1,32 @@
 import { cn } from '@/lib/styles/cn';
 import { glassBackgroundStyles, glassBorderStyles } from '@components';
+import { InteractiveControlSize } from '@components/primitives/interactive-control';
 
 const groupBase = ['inline-flex'];
 
 const itemBase = [
-  'relative inline-flex items-center justify-center min-w-6 min-h-6 text-xs font-medium',
-  'rounded-none p-0 ', // todo glasscards padding is applied which is not ideal, we should be able to control it from here
-
+  'relative inline-flex items-center justify-center min-w-6 min-h-6 select-none border',
   'first:rounded-s-md last:rounded-e-md',
   '[&:not(:first-child)]:border-s-0',
   'text-text-primary',
-  'transition-colors',
+  'transition-[background-color,border-color,color,transform,box-shadow,opacity] duration-150 ease-out',
   'focus-visible:outline-none',
-  'overflow-hidden',
+  'overflow-hidden border border-border-primary',
 ];
 
-const itemRACState = [
-  'data-[hovered]:bg-text-primary data-[hovered]:text-bg-primary',
-  'data-[selected]:bg-text-primary data-[selected]:text-bg-primary',
-  'data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed',
+const itemRACState = ['data-[hovered]:bg-bg-secondary', 'data-[disabled]:cursor-not-allowed'];
+
+const indicatorBase = ['absolute inset-0'];
+
+const indicatorRACState = [
+  'opacity-0 transition-opacity data-[selected]:bg-slate-950/15 dark:data-[selected]:bg-white/20 data-[selected]:opacity-100 ',
 ];
-
-const indicatorBase = ['absolute inset-0', 'bg-text-primary'];
-
-const indicatorRACState = ['data-[selected]:opacity-100 opacity-0 transition-opacity'];
 
 const labelBase = 'relative z-10';
 
 export const segmentedControlGroupStyles = {
   group: () => cn(groupBase),
-  item: () =>
-    cn(
-      glassBackgroundStyles({ blur: 'sm', intensity: 'low' }),
-      glassBorderStyles({ border: 'low' }),
-      itemBase,
-      itemRACState,
-    ),
+  item: () => cn(itemBase, itemRACState),
   indicator: () => cn(indicatorBase, indicatorRACState),
   label: () => cn(labelBase),
 };

--- a/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.tsx
+++ b/containers/frontend/web/src/components/composites/segmented-control-group/segmented-control-group.tsx
@@ -43,6 +43,7 @@ function SegmentedControlItem(props: ToggleButtonProps) {
   );
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function SegmentedControlGroup({
   options,
   defaultSelectedKey,
@@ -86,9 +87,7 @@ export function SegmentedControlGroup({
           </SegmentedControlItem>
         );
 
-        if (!opt.tooltipLabel) {
-          return item;
-        }
+        if (!opt.tooltipLabel) return item;
 
         return (
           <TooltipTrigger

--- a/containers/frontend/web/src/components/primitives/glass-card/glass-card.styles.ts
+++ b/containers/frontend/web/src/components/primitives/glass-card/glass-card.styles.ts
@@ -27,7 +27,7 @@ const border = {
 } as const;
 
 const cardLayout = [
-  'shadow-[0_8px_32px_0_rgba(0,0,0,0.08)]',
+  'shadow-[0_8px_32px_rgba(var(--color-shadow-rgb),var(--color-shadow-opacity))]',
   'rounded-3xl p-8',
   'transition-all duration-300',
 ];

--- a/containers/frontend/web/src/components/primitives/message-bubble/message-bubble.styles.ts
+++ b/containers/frontend/web/src/components/primitives/message-bubble/message-bubble.styles.ts
@@ -3,8 +3,8 @@ import { cn } from '@/lib/styles/cn';
 const messageBubbleBase = 'p-3 rounded-xl gap-2 flex flex-col max-w-[90%] md:max-w-[80%]';
 
 const messageVariant = {
-  me: 'rounded-br-none bg-slate-300 ms-auto',
-  user: 'rounded-bl-none bg-slate-100',
+  me: 'rounded-br-none bg-bg-secondary ms-auto',
+  user: 'rounded-bl-none bg-bg-primary border border-border-primary',
   system: 'bg-yellow-400',
   error: 'bg-red-400 text-white',
   'game-event': 'bg-green-400 text-white',

--- a/containers/frontend/web/src/features/chat/chat.store.ts
+++ b/containers/frontend/web/src/features/chat/chat.store.ts
@@ -31,7 +31,7 @@ export const CHAT_MESSAGES = [
   },
   {
     id: '5',
-    username: 'mvelazqu',
+    username: 'joanavar',
     content: {
       text: 'Yes, and also prevent jump when user scrolls up. Classic chat problem 😅',
     },
@@ -64,7 +64,7 @@ export const CHAT_MESSAGES = [
   },
   {
     id: '9',
-    username: 'mvelazqu',
+    username: 'joanavar',
     content: {
       text: 'Also we need to think about rate limiting before exposing public API.',
     },

--- a/containers/frontend/web/src/features/chat/chat.styles.ts
+++ b/containers/frontend/web/src/features/chat/chat.styles.ts
@@ -1,9 +1,9 @@
 export const chatStyles = {
   wrapper:
-    'h-full bg-white/50 backdrop-blur-sm rounded-xl overflow-hidden border-l border-gray-200',
+    'h-full bg-bg-primary/50 dark:bg-bg-primary/30 backdrop-blur-sm rounded-xl overflow-hidden border-l border-border-primary',
 
   header: {
-    wrapper: 'px-5 py-3 relative z-10 shadow-md bg-white',
+    wrapper: 'px-5 py-3 relative z-10 bg-bg-primary shadow-header',
   },
   main: {
     wrapper: 'px-3 py-4',

--- a/containers/frontend/web/src/features/chat/chat.styles.ts
+++ b/containers/frontend/web/src/features/chat/chat.styles.ts
@@ -9,5 +9,9 @@ export const chatStyles = {
   main: {
     wrapper: 'px-3 py-4',
   },
-  footer: { input: 'rounded-none shadow-md px-3' },
+  footer: {
+    wrapper:
+      'relative z-10 bg-bg-primary shadow-[0_-4px_6px_-1px_rgba(var(--color-shadow-rgb),var(--color-shadow-opacity)),0_-2px_4px_-2px_rgba(var(--color-shadow-rgb),var(--color-shadow-opacity))]',
+    input: 'rounded-none px-3 border-none',
+  },
 };

--- a/containers/frontend/web/src/features/chat/chat.styles.ts
+++ b/containers/frontend/web/src/features/chat/chat.styles.ts
@@ -4,7 +4,7 @@ export const chatStyles = {
 
   header: {
     wrapper:
-      'px-5 py-3 relative z-10 bg-bg-primary shadow-[0_4px_6px_-1px_rgb(var(--color-shadow)),0_2px_4px_-2px_rgb(var(--color-shadow)/0.12)]',
+      'px-5 py-3 relative z-10 bg-bg-primary shadow-[0_4px_6px_-1px_rgba(var(--color-shadow-rgb),var(--color-shadow-opacity)),0_2px_4px_-2px_rgba(var(--color-shadow-rgb),var(--color-shadow-opacity))]',
   },
   main: {
     wrapper: 'px-3 py-4',

--- a/containers/frontend/web/src/features/chat/chat.styles.ts
+++ b/containers/frontend/web/src/features/chat/chat.styles.ts
@@ -3,7 +3,8 @@ export const chatStyles = {
     'h-full bg-bg-primary/50 dark:bg-bg-primary/30 backdrop-blur-sm rounded-xl overflow-hidden border-l border-border-primary',
 
   header: {
-    wrapper: 'px-5 py-3 relative z-10 bg-bg-primary shadow-header',
+    wrapper:
+      'px-5 py-3 relative z-10 bg-bg-primary shadow-[0_4px_6px_-1px_rgb(var(--color-shadow)),0_2px_4px_-2px_rgb(var(--color-shadow)/0.12)]',
   },
   main: {
     wrapper: 'px-3 py-4',

--- a/containers/frontend/web/src/features/chat/chat.tsx
+++ b/containers/frontend/web/src/features/chat/chat.tsx
@@ -23,6 +23,7 @@ function ChatContent() {
           e.preventDefault();
           sendMessage();
         }}
+        className={chatStyles.footer.wrapper}
       >
         <TextAreaField
           value={value}

--- a/containers/frontend/web/src/features/chat/chat.tsx
+++ b/containers/frontend/web/src/features/chat/chat.tsx
@@ -14,7 +14,7 @@ function ChatContent() {
 
   return (
     <Stack gap="none" className={chatStyles.wrapper}>
-      <ChatHeader room="chatTest" participants={['capapes', 'cmanica-', 'mfontser', 'mvelazqu']} />
+      <ChatHeader room="chatTest" participants={['capapes', 'cmanica-', 'mfontser', 'joanavar']} />
 
       <ChatMain messages={messages} />
 

--- a/containers/frontend/web/src/features/navigation/navigation-main/navigation-main.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation-main/navigation-main.tsx
@@ -82,12 +82,7 @@ export function NavigationMain(args: NavigationMainProps) {
   const t = useTranslations('features.navigation');
 
   return (
-    <Stack
-      className="flex-1 list w-full shadow-[8px_0_20px_var(--color-shadow)]"
-      gap="sm"
-      align="stretch"
-      role="list"
-    >
+    <Stack className="flex-1 list w-full" gap="sm" align="stretch" role="list">
       {mainNavItems.map((item) => (
         <NavLinkItem key={item.href} navItem={item} />
       ))}

--- a/containers/frontend/web/src/features/navigation/navigation-main/navigation-main.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation-main/navigation-main.tsx
@@ -82,7 +82,12 @@ export function NavigationMain(args: NavigationMainProps) {
   const t = useTranslations('features.navigation');
 
   return (
-    <Stack className="flex-1 list w-full" gap="sm" align="stretch" role="list">
+    <Stack
+      className="flex-1 list w-full shadow-[8px_0_20px_var(--color-shadow)]"
+      gap="sm"
+      align="stretch"
+      role="list"
+    >
       {mainNavItems.map((item) => (
         <NavLinkItem key={item.href} navItem={item} />
       ))}

--- a/containers/frontend/web/src/features/navigation/navigation.client.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation.client.tsx
@@ -31,7 +31,7 @@ const mobileNavigationClassName = glassCardStyles({
   intensity: 'medium',
   blur: 'sm',
   className:
-    'group z-10 flex max-h-[100dvh] w-full overflow-y-auto overscroll-contain px-2 py-4 rounded-s-none rounded-e-md',
+    'group z-10 flex h-full w-full overflow-y-auto overscroll-contain px-2 py-4 rounded-none',
 });
 
 export function useMediaQuery(query: string) {

--- a/containers/frontend/web/src/features/navigation/navigation.client.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation.client.tsx
@@ -27,12 +27,8 @@ function getMobileNavigationValue(locale: string, closeNavigation: () => void) {
   };
 }
 
-const mobileNavigationClassName = glassCardStyles({
-  intensity: 'medium',
-  blur: 'sm',
-  className:
-    'group z-10 flex h-full w-full overflow-y-auto overscroll-contain px-2 py-4 rounded-none',
-});
+const mobileNavigationClassName =
+  'group z-10 flex h-[100dvh] w-full overflow-y-auto overscroll-contain px-2 py-4 rounded-s-none rounded-e-md';
 
 export function useMediaQuery(query: string) {
   const [matches, setMatches] = useState<boolean | null>(null);

--- a/containers/frontend/web/src/i18n/messages/ca.json
+++ b/containers/frontend/web/src/i18n/messages/ca.json
@@ -374,7 +374,7 @@
     "OUT_OF_RANGE": "Sol·licitud fora de rang"
   },
   "errors": {
-    "AUTH_EMAIL_ALREADY_EXISTS": "Aquest email ja existeix",
+    "AUTH_EMAIL_ALREADY_EXISTS": "Aquest correu electrònic ja existeix",
     "AUTH_INVALID_CREDENTIALS": "Credencials no vàlides",
     "AUTH_ACCOUNT_LOCKED": "El teu compte està bloquejat temporalment. Torna-ho a provar més tard.",
     "AUTH_RATE_LIMITED": "Massa intents. Torna-ho a provar més tard.",

--- a/containers/frontend/web/src/i18n/messages/es.json
+++ b/containers/frontend/web/src/i18n/messages/es.json
@@ -374,7 +374,7 @@
     "OUT_OF_RANGE": "Solicitud fuera de rango."
   },
   "errors": {
-    "AUTH_EMAIL_ALREADY_EXISTS": "El email ya existe",
+    "AUTH_EMAIL_ALREADY_EXISTS": "El correo electrónico ya existe",
     "AUTH_INVALID_CREDENTIALS": "Credenciales inválidas",
     "AUTH_ACCOUNT_LOCKED": "Tu cuenta está bloqueada temporalmente. Inténtalo más tarde.",
     "AUTH_RATE_LIMITED": "Demasiados intentos. Inténtalo más tarde.",


### PR DESCRIPTION
This pull request focuses on improving visual consistency across the UI by standardizing color and shadow usage, refining glassmorphism effects, and updating language for clarity in translations. The main changes are grouped below:

**UI Theming and Consistency:**

* Added new CSS variables for header shadows in both light and dark modes, and created a reusable `.shadow-header` utility class in `globals.css` for consistent header shadow styling. [[1]](diffhunk://#diff-8a7c426452812bb8f468b2c6cd7bfa34dc22e8a08008c85751da57016b30f836R84-R86) [[2]](diffhunk://#diff-8a7c426452812bb8f468b2c6cd7bfa34dc22e8a08008c85751da57016b30f836R99-R100) [[3]](diffhunk://#diff-8a7c426452812bb8f468b2c6cd7bfa34dc22e8a08008c85751da57016b30f836R272-R275)
* Updated `message-bubble.styles.ts` to use theme variables for background and border colors, ensuring message bubbles adapt to light/dark modes and align with the overall design system.
* Refined `drawer.styles.ts` to use theme-based background, border, and blur effects for both overlay and drawer, improving the glassmorphism effect and consistency with the rest of the UI. [[1]](diffhunk://#diff-3655ab737eb97f95a6991a33cbc7701525c6bcb2371d9c2f0b6e9f3fdfd91206L6-R6) [[2]](diffhunk://#diff-3655ab737eb97f95a6991a33cbc7701525c6bcb2371d9c2f0b6e9f3fdfd91206L20-R26)
* Updated `chat.styles.ts` to use theme variables for backgrounds, borders, and header shadows, further standardizing the chat appearance.
* Adjusted navigation drawer styles in `navigation.client.tsx` for better edge alignment and to remove unnecessary rounding, aligning with the updated glassmorphism design.