### PR TITLE
197 auth authenticate socketio connections using shared redis backed sessions

### DIFF
--- a/containers/backend/app/scripts/curl-command.sh
+++ b/containers/backend/app/scripts/curl-command.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-#BASE="https://localhost:8443/api"
-BASE="http://localhost:4000"
+#BASE="http://localhost:4000"
+BASE="https://localhost:8443/api"
+CACERT="../../../../certs/ca.pem"
 COOKIES="./src/scripts/cookies.txt"
 
 EMAIL="test$(date +%s)@example.com"
@@ -14,7 +15,7 @@ echo "-----------------------------------"
 echo "Signup"
 echo "-----------------------------------"
 
-curl -k -X POST "$BASE/auth/signup" \
+curl --cacert "$CACERT" -X POST "$BASE/auth/signup" \
   -H "Content-Type: application/json" \
   -d "{
     \"email\": \"$EMAIL\",
@@ -28,7 +29,7 @@ echo "-----------------------------------"
 echo "Login (saving cookies)"
 echo "-----------------------------------"
 
-curl -k -X POST "$BASE/auth/login" \
+curl --cacert "$CACERT" -X POST "$BASE/auth/login" \
   -H "Content-Type: application/json" \
   -c "$COOKIES" \
   -d "{
@@ -43,7 +44,7 @@ echo "-----------------------------------"
 echo "Get users"
 echo "-----------------------------------"
 
-curl -k "$BASE/users?limit=25&offset=0" \
+curl --cacert "$CACERT" "$BASE/users?limit=25&offset=0" \
   -b "$COOKIES"
 
 echo ""
@@ -53,7 +54,7 @@ echo "-----------------------------------"
 echo "Logout"
 echo "-----------------------------------"
 
-curl -k -X POST "$BASE/auth/logout" \
+curl --cacert "$CACERT" -X POST "$BASE/auth/logout" \
   -b "$COOKIES"
 
 echo ""

--- a/containers/backend/app/scripts/smoke-friendships.mjs
+++ b/containers/backend/app/scripts/smoke-friendships.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 /**
  * Smoke test: signup x2 → login → friend request → accept → GET /friends & /friendships.
- * Run inside backend container: BASE_URL=http://127.0.0.1:4000 node scripts/smoke-friendships.mjs
+ * Run inside backend container: BASE_URL=https://localhost:8443/api node scripts/smoke-friendships.mjs
  */
 
-const BASE = process.env.BASE_URL ?? 'http://127.0.0.1:4000';
+const BASE = process.env.BASE_URL ?? 'https://localhost:8443/api';
 
 class Client {
   /** @type {string} */

--- a/containers/backend/app/scripts/smoke-friendships.mjs
+++ b/containers/backend/app/scripts/smoke-friendships.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
  * Smoke test: signup x2 → login → friend request → accept → GET /friends & /friendships.
- * Run inside backend container: BASE_URL=https://localhost:8443/api node scripts/smoke-friendships.mjs
+ * Run inside backend container: node scripts/smoke-friendships.mjs
+ * Optional nginx route from a container on the edge network: BASE_URL=https://nginx/api node scripts/smoke-friendships.mjs
  */
 
-const BASE = process.env.BASE_URL ?? 'https://localhost:8443/api';
+const BASE = process.env.BASE_URL ?? 'https://localhost:4000';
 
 class Client {
   /** @type {string} */

--- a/containers/backend/app/scripts/smoke/smoke.config.ts
+++ b/containers/backend/app/scripts/smoke/smoke.config.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = process.env.BASE_URL ?? 'http://localhost:4000/';
+export const BASE_URL = process.env.BASE_URL ?? 'https://localhost:8443/api/';
 
 export const TEST_EMAIL = process.env.AUTH_TEST_EMAIL ?? 'capapes@fakemail.com';
 export const TEST_PASSWORD = process.env.AUTH_TEST_PASSWORD ?? 'Password123!';

--- a/containers/backend/app/src/auth/local/local.controller.ts
+++ b/containers/backend/app/src/auth/local/local.controller.ts
@@ -46,17 +46,6 @@ type SessionIdentityRes = {
   error?: { code: AuthErrorName };
 };
 
-type GuestSessionReq = {
-  guestId?: string;
-};
-
-function sanitizeGuestId(raw: unknown): string | null {
-  if (typeof raw !== 'string') return null;
-  const cleaned = raw.trim().toLowerCase();
-  if (!/^[a-z0-9_-]{8,64}$/.test(cleaned)) return null;
-  return cleaned;
-}
-
 function toGuestUsername(guestId: string): string {
   return `guest-${guestId.slice(0, 8)}`;
 }
@@ -102,7 +91,7 @@ export async function postLogin(
 }
 
 export async function postGuestSession(
-  req: Request<unknown, unknown, GuestSessionReq>,
+  req: Request,
   res: Response<SessionIdentityRes>,
 ): Promise<void> {
   if (req.session.userId) {
@@ -125,8 +114,7 @@ export async function postGuestSession(
     return;
   }
 
-  const requestedGuestId = sanitizeGuestId(req.body?.guestId);
-  const guestId = requestedGuestId ?? req.session.guestId ?? newGuestId();
+  const guestId = req.session.guestId ?? newGuestId();
   const guestUsername = req.session.guestUsername ?? toGuestUsername(guestId);
 
   req.session.guestId = guestId;

--- a/containers/backend/app/src/auth/local/local.controller.ts
+++ b/containers/backend/app/src/auth/local/local.controller.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
 
 import type { LoginRes, SignupRes } from '@contracts/auth/auth.contract';
 import { AUTH_ERRORS, type AuthErrorName } from '@contracts/auth/auth.errors';
@@ -6,6 +7,7 @@ import type { SignupReq, LoginReq } from '@contracts/auth/auth.validation';
 import { HttpStatus, HttpStatusCode } from '@contracts/http';
 
 import { normalizeEmailLocale } from '../mail';
+import * as SharedRepo from '../shared.repo';
 import * as Service from './local.service';
 
 function errorStatus(code: AuthErrorName): number {
@@ -30,6 +32,48 @@ function sendOk<TResponse>(
   } as TResponse);
 }
 
+type SessionIdentityData = {
+  identityKey: string;
+  username: string;
+  isGuest: boolean;
+  userId?: string;
+  guestId?: string;
+};
+
+type SessionIdentityRes = {
+  ok: boolean;
+  data?: SessionIdentityData;
+  error?: { code: AuthErrorName };
+};
+
+type GuestSessionReq = {
+  guestId?: string;
+};
+
+function sanitizeGuestId(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const cleaned = raw.trim().toLowerCase();
+  if (!/^[a-z0-9_-]{8,64}$/.test(cleaned)) return null;
+  return cleaned;
+}
+
+function toGuestUsername(guestId: string): string {
+  return `guest-${guestId.slice(0, 8)}`;
+}
+
+function newGuestId(): string {
+  return randomUUID().replaceAll('-', '').slice(0, 24);
+}
+
+function guestIdentity(guestId: string, guestUsername: string): SessionIdentityData {
+  return {
+    identityKey: `guest:${guestId}`,
+    username: guestUsername,
+    isGuest: true,
+    guestId,
+  };
+}
+
 export async function postSignup(
   req: Request<unknown, unknown, SignupReq>,
   res: Response<SignupRes>,
@@ -48,11 +92,93 @@ export async function postLogin(
   req.session.regenerate((err) => {
     if (err) return sendError(res, 'AUTH_INTERNAL_ERROR');
     req.session.userId = result.id;
+    req.session.guestId = undefined;
+    req.session.guestUsername = undefined;
     req.session.save((saveErr) => {
       if (saveErr) return sendError(res, 'AUTH_INTERNAL_ERROR');
       sendOk(res, { user: result }, 200);
     });
   });
+}
+
+export async function postGuestSession(
+  req: Request<unknown, unknown, GuestSessionReq>,
+  res: Response<SessionIdentityRes>,
+): Promise<void> {
+  if (req.session.userId) {
+    const user = await SharedRepo.findUserById(req.session.userId);
+    if (!user) {
+      sendError(res, 'AUTH_UNAUTHORIZED');
+      return;
+    }
+
+    sendOk(
+      res,
+      {
+        identityKey: `user:${user.id}`,
+        username: user.username,
+        isGuest: false,
+        userId: user.id,
+      },
+      200,
+    );
+    return;
+  }
+
+  const requestedGuestId = sanitizeGuestId(req.body?.guestId);
+  const guestId = requestedGuestId ?? req.session.guestId ?? newGuestId();
+  const guestUsername = req.session.guestUsername ?? toGuestUsername(guestId);
+
+  req.session.guestId = guestId;
+  req.session.guestUsername = guestUsername;
+
+  req.session.save((err) => {
+    if (err) {
+      sendError(res, 'AUTH_INTERNAL_ERROR');
+      return;
+    }
+
+    sendOk(res, guestIdentity(guestId, guestUsername), 200);
+  });
+}
+
+export async function getSessionIdentity(
+  req: Request,
+  res: Response<SessionIdentityRes>,
+): Promise<void> {
+  if (req.session.userId) {
+    const user = await SharedRepo.findUserById(req.session.userId);
+    if (!user) {
+      sendError(res, 'AUTH_UNAUTHORIZED');
+      return;
+    }
+
+    sendOk(
+      res,
+      {
+        identityKey: `user:${user.id}`,
+        username: user.username,
+        isGuest: false,
+        userId: user.id,
+      },
+      200,
+    );
+    return;
+  }
+
+  if (!req.session.guestId) {
+    sendError(res, 'AUTH_UNAUTHORIZED');
+    return;
+  }
+
+  const guestId = req.session.guestId;
+  const guestUsername = req.session.guestUsername ?? toGuestUsername(guestId);
+
+  if (!req.session.guestUsername) {
+    req.session.guestUsername = guestUsername;
+  }
+
+  sendOk(res, guestIdentity(guestId, guestUsername), 200);
 }
 
 export function postLogout(req: Request, res: Response): void {

--- a/containers/backend/app/src/auth/local/local.routes.ts
+++ b/containers/backend/app/src/auth/local/local.routes.ts
@@ -9,7 +9,13 @@ import {
   localSignupEmailRateLimit,
 } from './local.rate-limit';
 
-import { postLogin, postLogout, postSignup } from './local.controller';
+import {
+  getSessionIdentity,
+  postGuestSession,
+  postLogin,
+  postLogout,
+  postSignup,
+} from './local.controller';
 
 export const localRouter = Router();
 
@@ -22,3 +28,5 @@ localRouter.post(
   postLogin,
 );
 localRouter.post('/logout', postLogout);
+localRouter.post('/guest/session', postGuestSession);
+localRouter.get('/session/identity', getSessionIdentity);

--- a/containers/backend/app/src/auth/oauth/oauth.controller.ts
+++ b/containers/backend/app/src/auth/oauth/oauth.controller.ts
@@ -36,6 +36,8 @@ export function getGoogleCallback(req: Request, res: Response, next: NextFunctio
     req.session.regenerate((regenErr) => {
       if (regenErr) return next(regenErr);
       req.session.userId = userId;
+      req.session.guestId = undefined;
+      req.session.guestUsername = undefined;
       req.session.save((saveErr) => {
         if (saveErr) return next(saveErr);
         return res.status(302).redirect('/profile');

--- a/containers/backend/app/src/auth/verification/verification.controller.ts
+++ b/containers/backend/app/src/auth/verification/verification.controller.ts
@@ -60,6 +60,8 @@ export async function postVerifyEmail(
   req.session.regenerate((regenErr) => {
     if (regenErr) return sendError(res, 'AUTH_INTERNAL_ERROR');
     req.session.userId = user.id;
+    req.session.guestId = undefined;
+    req.session.guestUsername = undefined;
     req.session.save((saveErr) => {
       if (saveErr) return sendError(res, 'AUTH_INTERNAL_ERROR');
       res.status(200).json({ ok: true, data: null });

--- a/containers/backend/app/src/friendships/friendships.notify.ts
+++ b/containers/backend/app/src/friendships/friendships.notify.ts
@@ -1,4 +1,4 @@
-const SOCKET_SERVICE_URL = process.env.SOCKET_SERVICE_URL ?? 'http://socket:3100';
+const SOCKET_SERVICE_URL = process.env.SOCKET_SERVICE_URL ?? 'https://socket:3100';
 
 type UserBrief = { userId: string; username: string };
 

--- a/containers/backend/app/src/friendships/friendships.presence.ts
+++ b/containers/backend/app/src/friendships/friendships.presence.ts
@@ -1,4 +1,4 @@
-const SOCKET_SERVICE_URL = process.env.SOCKET_SERVICE_URL ?? 'http://socket:3100';
+const SOCKET_SERVICE_URL = process.env.SOCKET_SERVICE_URL ?? 'https://socket:3100';
 
 export async function resolveOnlineStatus(userIds: string[]): Promise<Record<string, boolean>> {
   if (userIds.length === 0) return {};

--- a/containers/backend/app/src/index.ts
+++ b/containers/backend/app/src/index.ts
@@ -1,12 +1,35 @@
 import app from './app';
 import { connectRedis } from './shared/redis.client';
+import { existsSync, readFileSync } from 'fs';
+import { createServer as createHttpsServer } from 'https';
+import { join } from 'path';
 
 const PORT = Number(process.env.PORT ?? 4000);
+const CERT_DIR = process.env.CERT_DIR;
 
 function listen(port: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    const server = app.listen(port, () => {
-      console.log(`Server running on port ${port}`);
+    if (!CERT_DIR) {
+      throw new Error('CERT_DIR is required');
+    }
+
+    const certPath = join(CERT_DIR, 'localhost.crt');
+    const keyPath = join(CERT_DIR, 'localhost.key');
+
+    if (!existsSync(certPath) || !existsSync(keyPath)) {
+      throw new Error(`TLS certs not found in ${CERT_DIR}`);
+    }
+
+    const server = createHttpsServer(
+      {
+        cert: readFileSync(certPath),
+        key: readFileSync(keyPath),
+      },
+      app,
+    );
+
+    server.listen(port, () => {
+      console.log(`Server running on port ${port} over HTTPS`);
       resolve();
     });
 

--- a/containers/backend/app/src/shared/session.d.ts
+++ b/containers/backend/app/src/shared/session.d.ts
@@ -3,5 +3,7 @@ import 'express-session';
 declare module 'express-session' {
   interface SessionData {
     userId?: string;
+    guestId?: string;
+    guestUsername?: string;
   }
 }

--- a/containers/contracts/sockets/chat/chat.schema.ts
+++ b/containers/contracts/sockets/chat/chat.schema.ts
@@ -18,6 +18,7 @@ export type ServerToClientChatEvents = {
   'chat:system': (payload: ChatSystemMessage) => void;
   'chat:error': (payload: ChatError) => void;
   'chat:history': (payload: ChatHistoryType) => void;
+  'chat:identity': (payload: ChatIdentity) => void;
   'chat:game-event': (payload: ChatGameEvent) => void;
 };
 
@@ -107,6 +108,15 @@ export const ChatGameEventSchema = BaseMessageSchema.extend({
 });
 
 export type ChatGameEvent = z.infer<typeof ChatGameEventSchema>;
+
+export const ChatIdentitySchema = z.object({
+  identityKey: z.string(),
+  username: z.string(),
+  isGuest: z.boolean(),
+  userId: z.string().optional(),
+});
+
+export type ChatIdentity = z.infer<typeof ChatIdentitySchema>;
 
 // ---------------------------------------------------------------
 // union

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -31,10 +31,14 @@ services:
       context: ./socket
       dockerfile: ./docker/Dockerfile
     working_dir: /app
+    depends_on:
+      backend:
+        condition: service_healthy
     environment:
       NODE_ENV: development
       CERT_DIR: /certs
       NODE_EXTRA_CA_CERTS: /certs/ca.pem
+      BACKEND_SESSION_IDENTITY_URL: https://backend:4000/auth/session/identity
     volumes:
       - ./socket/app:/app
       - node_modules_socket:/app/node_modules

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -31,8 +31,6 @@ services:
       context: ./socket
       dockerfile: ./docker/Dockerfile
     working_dir: /app
-    ports:
-      - "3100:3100"
     environment:
       NODE_ENV: development
     volumes:

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -33,9 +33,12 @@ services:
     working_dir: /app
     environment:
       NODE_ENV: development
+      CERT_DIR: /certs
+      NODE_EXTRA_CA_CERTS: /certs/ca.pem
     volumes:
       - ./socket/app:/app
       - node_modules_socket:/app/node_modules
+      - ${CERT_DIR:-../certs}:/certs:ro
       - ./contracts:/app/src/contracts
     networks:
       - edge
@@ -54,12 +57,21 @@ services:
       - node_modules:/app/node_modules
       - frontend_next_cache:/app/.next
       - /app/dev
+      - ${CERT_DIR:-../certs}:/certs:ro
       - ./contracts:/app/src/contracts:ro
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "--cacert",
+          "/certs/ca.pem",
+          "-f",
+          "https://localhost:3000/api/health",
+        ]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -80,18 +92,29 @@ services:
         condition: service_healthy
     environment:
       REDIS_URL: redis://redis:6379
-      SOCKET_SERVICE_URL: http://socket:3100
+      SOCKET_SERVICE_URL: https://socket:3100
+      CERT_DIR: /certs
+      NODE_EXTRA_CA_CERTS: /certs/ca.pem
     env_file:
       - ./backend/docker/.env.development
     volumes:
       - ./backend/app:/app
       - node_modules_backend:/app/node_modules
+      - ${CERT_DIR:-../certs}:/certs:ro
       - ./contracts:/app/src/contracts
     networks:
       - backend
       - edge
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "--cacert",
+          "/certs/ca.pem",
+          "-f",
+          "https://localhost:4000/health",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/containers/frontend/web/next-env.d.ts
+++ b/containers/frontend/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/containers/frontend/web/next-env.d.ts
+++ b/containers/frontend/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/containers/frontend/web/next.config.ts
+++ b/containers/frontend/web/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ['lucide-react', 'react-aria-components'],
   },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 const withNextIntl = createNextIntlPlugin({

--- a/containers/frontend/web/package.json
+++ b/containers/frontend/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --experimental-https --experimental-https-key /certs/localhost.key --experimental-https-cert /certs/localhost.crt --experimental-https-ca /certs/ca.pem",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint src scripts --cache",

--- a/containers/frontend/web/src/app/[locale]/(public)/ui/(margin)/layout.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/ui/(margin)/layout.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from 'react';
 
-export default function marginPage({ children }: { ReactNode }) {
+type LayoutProps = {
+  children: ReactNode;
+};
+
+export default function Layout({ children }: LayoutProps) {
   return <main className="p-4 md:ps-10 w-full">{children}</main>;
 }

--- a/containers/frontend/web/src/app/global-error.tsx
+++ b/containers/frontend/web/src/app/global-error.tsx
@@ -1,32 +1,23 @@
 'use client';
 
-import enMessages from '@/i18n/messages/en.json';
-import esMessages from '@/i18n/messages/es.json';
-import caMessages from '@/i18n/messages/ca.json';
-import { getLocaleFromDocument } from '@/i18n/get-locale-from-document';
-
-const globalMessages = {
-  en: enMessages.common.globalError,
-  es: esMessages.common.globalError,
-  ca: caMessages.common.globalError,
-} as const;
-
 export default function GlobalError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const locale = getLocaleFromDocument();
-  const t = globalMessages[locale];
+  console.error(error);
 
   return (
-    <html lang={locale}>
+    <html lang="en">
       <body>
-        <h1>{t.title}</h1>
-        <button type="button" onClick={() => reset()}>
-          {t.tryAgain}
-        </button>
+        <main>
+          <h1>Something went wrong</h1>
+          <button type="button" onClick={() => reset()}>
+            Try again
+          </button>
+        </main>
       </body>
     </html>
   );

--- a/containers/frontend/web/src/features/chat/chat.provider.tsx
+++ b/containers/frontend/web/src/features/chat/chat.provider.tsx
@@ -14,6 +14,7 @@ import {
 import type {
   ChatGameEvent,
   ChatHistoryType,
+  ChatIdentity,
   ChatMe,
   ChatMessage,
   ChatMessageUnion,
@@ -35,14 +36,13 @@ type ChatProviderProps = {
   children: ReactNode;
 };
 
-// TODO These formatting functions can be removed once the backend can
-// identify the authenticated user and emit the correct renderable type.
+const formatMessage = (message: ChatMessage, selfUsername: string | null): ChatMessageUnion =>
+  selfUsername && message.username === selfUsername ? { ...message, type: 'me' } : message;
 
-const formatMessage = (message: ChatMessage): ChatMessageUnion =>
-  message.username !== 'me' ? message : { ...message, type: 'me' };
-
-const formatHistory = (history: ChatHistoryType): ChatHistoryType =>
-  history.map((message) => (message.type !== 'user' ? message : formatMessage(message)));
+const formatHistory = (history: ChatHistoryType, selfUsername: string | null): ChatHistoryType =>
+  history.map((message) =>
+    message.type !== 'user' ? message : formatMessage(message, selfUsername),
+  );
 
 const gameEventMessage = (event: string): ChatGameEvent => ({
   id: `event-${Date.now()}`,
@@ -64,10 +64,15 @@ const optimisticMessage = (text: string): ChatMe => ({
   createdAt: Date.now(),
 });
 
-function useChatMessages(setMessages: Dispatch<SetStateAction<ChatHistoryType>>) {
+function useChatMessages(
+  setMessages: Dispatch<SetStateAction<ChatHistoryType>>,
+  selfUsername: string | null,
+  setSelfUsername: Dispatch<SetStateAction<string | null>>,
+) {
   const handleChatMessage = useCallback(
-    (message: ChatMessage) => setMessages((prev) => [...prev, formatMessage(message)]),
-    [setMessages],
+    (message: ChatMessage) =>
+      setMessages((prev) => [...prev, formatMessage(message, selfUsername)]),
+    [setMessages, selfUsername],
   );
 
   const handleChatSystemMessage = useCallback(
@@ -76,8 +81,16 @@ function useChatMessages(setMessages: Dispatch<SetStateAction<ChatHistoryType>>)
   );
 
   const handleChatHistory = useCallback(
-    (history: ChatHistoryType) => setMessages(formatHistory(history)),
-    [setMessages],
+    (history: ChatHistoryType) => setMessages(formatHistory(history, selfUsername)),
+    [setMessages, selfUsername],
+  );
+
+  const handleChatIdentity = useCallback(
+    (identity: ChatIdentity) => {
+      setSelfUsername(identity.username);
+      setMessages((prev) => formatHistory(prev, identity.username));
+    },
+    [setMessages, setSelfUsername],
   );
 
   const handleChatError = useCallback(
@@ -94,6 +107,7 @@ function useChatMessages(setMessages: Dispatch<SetStateAction<ChatHistoryType>>)
     handleChatMessage,
     handleChatSystemMessage,
     handleChatHistory,
+    handleChatIdentity,
     handleChatError,
     handleGameEvent,
   };
@@ -102,6 +116,7 @@ function useChatMessages(setMessages: Dispatch<SetStateAction<ChatHistoryType>>)
 // eslint-disable-next-line max-lines-per-function
 export function ChatProvider({ children }: ChatProviderProps) {
   const [messages, setMessages] = useState<ChatHistoryType>([]);
+  const [selfUsername, setSelfUsername] = useState<string | null>(null);
   const [value, setValue] = useState('');
 
   const sendMessage = useCallback(() => {
@@ -121,9 +136,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
     handleChatMessage,
     handleChatSystemMessage,
     handleChatHistory,
+    handleChatIdentity,
     handleChatError,
     handleGameEvent,
-  } = useChatMessages(setMessages);
+  } = useChatMessages(setMessages, selfUsername, setSelfUsername);
 
   const contextValue = useMemo(
     () => ({
@@ -142,6 +158,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
         onChatMessage={handleChatMessage}
         onChatSystemMessage={handleChatSystemMessage}
         onChatHistory={handleChatHistory}
+        onChatIdentity={handleChatIdentity}
         onChatError={handleChatError}
         onGameEvent={handleGameEvent}
       />

--- a/containers/frontend/web/src/i18n/messages/ca.json
+++ b/containers/frontend/web/src/i18n/messages/ca.json
@@ -309,6 +309,7 @@
         "sent": "T'hem enviat instruccions per restablir la contrasenya al correu que has introduït.",
         "checkInbox": "Revisa la teva safata d'entrada i segueix les instruccions per crear una nova contrasenya.",
         "checkSpam": "Si no el trobes, revisa la carpeta de correu brossa. Si tampoc hi és, prova-ho de nou més tard.",
+        "rememberedPassword": "Has recordat la teva contrasenya?",
         "backToLogin": "Torna a iniciar sessió"
       },
       "reset": {
@@ -321,8 +322,7 @@
       },
       "messages": {
         "or": "O",
-        "resendSuccess": "✓ Correu enviat. Espera per tornar-ho a intentar.",
-        "resendError": "✗ No s'ha pogut enviar. Torna-ho a intentar."
+        "success": "Correu enviat. Espera per tornar-ho a intentar."
       }
     },
     "navigation": {
@@ -384,6 +384,6 @@
     "AUTH_FORBIDDEN": "L'enllaç de verificació no és vàlid o ha caducat.",
     "AUTH_INTERNAL_ERROR": "Alguna cosa ha anat malament. Torna-ho a provar.",
     "VALIDATION_ERROR": "Error de validació: revisa els camps i intenta de nou.",
-    "FETCH_FAILED": "API request failed. Try again later."
+    "FETCH_FAILED": "Ha fallat la sol·licitud a l'API. Torna-ho a provar més tard."
   }
 }

--- a/containers/frontend/web/src/i18n/messages/en.d.json.ts
+++ b/containers/frontend/web/src/i18n/messages/en.d.json.ts
@@ -324,8 +324,7 @@ declare const messages: {
       },
       "messages": {
         "or": "OR",
-        "success": "Email sent. Wait before trying again.",
-        "submitting": "Submitting..."
+        "success": "Email sent. Wait before trying again."
       }
     },
     "navigation": {

--- a/containers/frontend/web/src/i18n/messages/en.json
+++ b/containers/frontend/web/src/i18n/messages/en.json
@@ -321,8 +321,7 @@
       },
       "messages": {
         "or": "OR",
-        "success": "Email sent. Wait before trying again.",
-        "submitting": "Submitting..."
+        "success": "Email sent. Wait before trying again."
       }
     },
     "navigation": {

--- a/containers/frontend/web/src/i18n/messages/es.json
+++ b/containers/frontend/web/src/i18n/messages/es.json
@@ -321,8 +321,7 @@
       },
       "messages": {
         "or": "O",
-        "resendSuccess": "✓ Correo enviado. Espera para volver a intentarlo.",
-        "resendError": "✗ No se pudo enviar. Inténtalo de nuevo."
+        "success": "Correo enviado. Espera para volver a intentarlo."
       }
     },
     "navigation": {
@@ -384,6 +383,6 @@
     "AUTH_FORBIDDEN": "El enlace de verificación no es válido o ha caducado.",
     "AUTH_INTERNAL_ERROR": "Algo salió mal. Vuelve a intentarlo.",
     "VALIDATION_ERROR": "Error de validación: revisa los campos e inténtalo de nuevo.",
-    "FETCH_FAILED": "API request failed. Try again later."
+    "FETCH_FAILED": "Ha fallado la solicitud a la API. Inténtalo de nuevo más tarde."
   }
 }

--- a/containers/frontend/web/src/lib/config/env.public.ts
+++ b/containers/frontend/web/src/lib/config/env.public.ts
@@ -6,6 +6,7 @@ function required(value: string | undefined, name: string): string {
 export const envPublic = {
   appUrl: required(process.env.NEXT_PUBLIC_APP_URL, 'NEXT_PUBLIC_APP_URL'),
   apiBaseUrl: required(process.env.NEXT_PUBLIC_API_BASE_URL, 'NEXT_PUBLIC_API_BASE_URL'),
+  socketUrl: required(process.env.NEXT_PUBLIC_SOCKET_URL, 'NEXT_PUBLIC_SOCKET_URL'),
   localeCookieName: required(
     process.env.NEXT_PUBLIC_LOCALE_COOKIE_NAME,
     'NEXT_PUBLIC_LOCALE_COOKIE_NAME',

--- a/containers/frontend/web/src/lib/sockets/socket-manager.tsx
+++ b/containers/frontend/web/src/lib/sockets/socket-manager.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 
-import { chatSocket, robotsSocket, type Robot } from './socket';
+import { chatSocket, ensureChatSessionIdentity, robotsSocket, type Robot } from './socket';
 import type {
   ChatError,
   ChatGameEvent,
   ChatHistoryType,
+  ChatIdentity,
   ChatMessage,
   ChatSystemMessage,
 } from '@/contracts/sockets/chat/chat.schema';
@@ -56,6 +57,7 @@ type ChatSocketManagerProps = {
   onChatSystemMessage: (message: ChatSystemMessage) => void;
   onChatError: (message: ChatError) => void;
   onChatHistory: (history: ChatHistoryType) => void;
+  onChatIdentity: (identity: ChatIdentity) => void;
   onGameEvent: (event: ChatGameEvent) => void;
 };
 
@@ -64,6 +66,7 @@ export const ChatSocketManager = ({
   onChatSystemMessage,
   onChatError,
   onChatHistory,
+  onChatIdentity,
   onGameEvent,
 }: ChatSocketManagerProps) => {
   useEffect(() => {
@@ -73,6 +76,7 @@ export const ChatSocketManager = ({
     const handleChatSystemMessage = (payload: ChatSystemMessage) => onChatSystemMessage(payload);
     const handleChatError = (payload: ChatError) => onChatError(payload);
     const handleChatHistory = (payload: ChatHistoryType) => onChatHistory(payload);
+    const handleChatIdentity = (payload: ChatIdentity) => onChatIdentity(payload);
     const handleGameEvent = (payload: ChatGameEvent) => onGameEvent(payload);
 
     const reservedListeners = [
@@ -81,6 +85,7 @@ export const ChatSocketManager = ({
     ] as const;
 
     const chatListeners = [
+      ['chat:identity', handleChatIdentity],
       ['chat:message', handleChatMessage],
       ['chat:system', handleChatSystemMessage],
       ['chat:error', handleChatError],
@@ -91,14 +96,25 @@ export const ChatSocketManager = ({
     reservedListeners.forEach(([event, handler]) => chatSocket.on(event, handler));
     chatListeners.forEach(([event, handler]) => chatSocket.on(event, handler));
 
-    chatSocket.connect();
+    let isMounted = true;
+
+    void ensureChatSessionIdentity()
+      .catch((error) => {
+        console.error('Failed to initialize chat session identity', error);
+      })
+      .finally(() => {
+        if (isMounted) {
+          chatSocket.connect();
+        }
+      });
 
     return () => {
+      isMounted = false;
       reservedListeners.forEach(([event, handler]) => chatSocket.off(event, handler));
       chatListeners.forEach(([event, handler]) => chatSocket.off(event, handler));
       chatSocket.disconnect();
     };
-  }, [onChatMessage, onChatSystemMessage, onChatError, onChatHistory, onGameEvent]);
+  }, [onChatMessage, onChatSystemMessage, onChatError, onChatHistory, onChatIdentity, onGameEvent]);
 
   return null;
 };

--- a/containers/frontend/web/src/lib/sockets/socket.ts
+++ b/containers/frontend/web/src/lib/sockets/socket.ts
@@ -1,10 +1,10 @@
 import { io, type Socket } from 'socket.io-client';
 
+import { envPublic } from '@/lib/config/env.public';
 import type {
   ServerToClientChatEvents,
   ClientToServerChatEvents,
 } from '@/contracts/sockets/chat/chat.schema';
-// TODO socket url as env variable
 
 export type Robot = {
   id: string;
@@ -20,16 +20,21 @@ type ClientToServerRobotsEvents = {
   moveTo: (target: [number, number, number]) => void;
 };
 
+const robotsSocketUrl = new URL('/robots', envPublic.socketUrl).toString();
+const chatSocketUrl = new URL('/chat', envPublic.socketUrl).toString();
+
 export const robotsSocket: Socket<ServerToClientRobotsEvents, ClientToServerRobotsEvents> = io(
-  'http://localhost:3100/robots',
+  robotsSocketUrl,
   {
     autoConnect: false,
+    transports: ['websocket'],
   },
 );
 
 export const chatSocket: Socket<ServerToClientChatEvents, ClientToServerChatEvents> = io(
-  'http://localhost:3100/chat',
+  chatSocketUrl,
   {
     autoConnect: false,
+    transports: ['websocket'],
   },
 );

--- a/containers/frontend/web/src/lib/sockets/socket.ts
+++ b/containers/frontend/web/src/lib/sockets/socket.ts
@@ -20,6 +20,22 @@ type ClientToServerRobotsEvents = {
   moveTo: (target: [number, number, number]) => void;
 };
 
+export async function ensureChatSessionIdentity(): Promise<void> {
+  const endpoint = `${envPublic.apiBaseUrl.replace(/\/$/, '')}/auth/guest/session`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to initialize chat session identity (${response.status})`);
+  }
+}
+
 const robotsSocketUrl = new URL('/robots', envPublic.socketUrl).toString();
 const chatSocketUrl = new URL('/chat', envPublic.socketUrl).toString();
 
@@ -28,6 +44,7 @@ export const robotsSocket: Socket<ServerToClientRobotsEvents, ClientToServerRobo
   {
     autoConnect: false,
     transports: ['websocket'],
+    withCredentials: true,
   },
 );
 
@@ -36,5 +53,7 @@ export const chatSocket: Socket<ServerToClientChatEvents, ClientToServerChatEven
   {
     autoConnect: false,
     transports: ['websocket'],
+    withCredentials: true,
+    auth: {},
   },
 );

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -11,6 +11,11 @@ http {
     server backend:4000;
     keepalive 16;
   }
+
+  upstream socket_upstream {
+    server socket:3100;
+    keepalive 16;
+  }
   
   limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=100r/m;
 
@@ -44,6 +49,18 @@ http {
       rewrite ^/api/(.*)$ /$1 break;
       proxy_pass http://backend_upstream;
       proxy_read_timeout 30s;
+    }
+
+    location ^~ /socket.io/ {
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_buffering off;
+      proxy_read_timeout 1h;
+      proxy_send_timeout 1h;
+
+      proxy_pass http://socket_upstream;
     }
 
     location / {

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -41,13 +41,23 @@ http {
       limit_req_status 429;
 
       rewrite ^/api/(.*)$ /$1 break;
-      proxy_pass http://backend_upstream;
+      proxy_ssl_server_name on;
+      proxy_ssl_name backend;
+      proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
+      proxy_ssl_verify on;
+      proxy_ssl_verify_depth 1;
+      proxy_pass https://backend_upstream;
       proxy_read_timeout 30s;
     }
 
     location ^~ /api/ {
       rewrite ^/api/(.*)$ /$1 break;
-      proxy_pass http://backend_upstream;
+      proxy_ssl_server_name on;
+      proxy_ssl_name backend;
+      proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
+      proxy_ssl_verify on;
+      proxy_ssl_verify_depth 1;
+      proxy_pass https://backend_upstream;
       proxy_read_timeout 30s;
     }
 
@@ -60,7 +70,12 @@ http {
       proxy_read_timeout 1h;
       proxy_send_timeout 1h;
 
-      proxy_pass http://socket_upstream;
+      proxy_ssl_server_name on;
+      proxy_ssl_name socket;
+      proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
+      proxy_ssl_verify on;
+      proxy_ssl_verify_depth 1;
+      proxy_pass https://socket_upstream;
     }
 
     location / {
@@ -80,7 +95,12 @@ http {
       proxy_set_header X-Forwarded-Port  $server_port;
       proxy_set_header Origin            $http_origin;
 
-      proxy_pass http://next_upstream;
+      proxy_ssl_server_name on;
+      proxy_ssl_name frontend;
+      proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
+      proxy_ssl_verify on;
+      proxy_ssl_verify_depth 1;
+      proxy_pass https://next_upstream;
     }
   }
 }

--- a/containers/nginx/scripts/test.sh
+++ b/containers/nginx/scripts/test.sh
@@ -2,7 +2,7 @@
 
 for i in {1..10}; do
   echo "Request $i"
-  curl -k -i \
+  curl --cacert ../../certs/ca.pem -i \
     -X POST https://localhost:8443/api/auth/login \
     -H "Content-Type: application/json" \
     -d '{"identifier":"test@example.com","password":"wrongpassword"}'

--- a/containers/socket/app/scripts/test.ts
+++ b/containers/socket/app/scripts/test.ts
@@ -6,7 +6,7 @@ script.src = 'https://cdn.socket.io/4.8.1/socket.io.min.js';
 document.head.appendChild(script);
 
 // Second
-const socket = io('http://localhost:3100/chat', {
+const socket = io('https://localhost:8443/chat', {
   path: '/socket.io',
   transports: ['websocket'],
 });

--- a/containers/socket/app/src/auth/session-auth.ts
+++ b/containers/socket/app/src/auth/session-auth.ts
@@ -1,0 +1,122 @@
+import type { Socket } from 'socket.io';
+
+type SessionIdentityResponse = {
+  ok: boolean;
+  data?: {
+    identityKey?: string;
+    username?: string;
+    isGuest?: boolean;
+    userId?: string;
+    guestId?: string;
+  };
+};
+
+export type SocketIdentity = {
+  identityKey: string;
+  username: string;
+  isGuest: boolean;
+  userId?: string;
+  guestId?: string;
+};
+
+const BACKEND_SESSION_IDENTITY_URL =
+  process.env.BACKEND_SESSION_IDENTITY_URL ??
+  process.env.BACKEND_SESSION_PROFILE_URL ??
+  process.env.BACKEND_SESSION_URL ??
+  'https://backend:4000/auth/session/identity';
+
+async function resolveIdentityFromSessionCookie(
+  cookieHeader: string,
+): Promise<SocketIdentity | null> {
+  const res = await fetch(BACKEND_SESSION_IDENTITY_URL, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Cookie: cookieHeader,
+    },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) return null;
+
+  const body = (await res.json().catch(() => null)) as SessionIdentityResponse | null;
+  const identityKey = body?.data?.identityKey;
+  const username = body?.data?.username;
+  const isGuest = body?.data?.isGuest;
+  const userId = body?.data?.userId;
+  const guestId = body?.data?.guestId;
+
+  if (typeof identityKey !== 'string' || identityKey.length === 0) return null;
+  if (typeof username !== 'string' || username.length === 0) return null;
+  if (typeof isGuest !== 'boolean') return null;
+
+  return {
+    identityKey,
+    username,
+    isGuest,
+    ...(typeof userId === 'string' ? { userId } : {}),
+    ...(typeof guestId === 'string' ? { guestId } : {}),
+  };
+}
+
+export async function requireSessionSocketAuth(
+  socket: Socket,
+  next: (err?: Error) => void,
+): Promise<void> {
+  const cookieHeader = socket.handshake.headers.cookie;
+
+  if (!cookieHeader) {
+    next(new Error('AUTH_UNAUTHORIZED'));
+    return;
+  }
+
+  try {
+    const identity = await resolveIdentityFromSessionCookie(cookieHeader);
+
+    if (!identity || identity.isGuest || !identity.userId) {
+      next(new Error('AUTH_UNAUTHORIZED'));
+      return;
+    }
+
+    socket.data.userId = identity.userId;
+    socket.data.username = identity.username;
+    socket.data.identityKey = identity.identityKey;
+    socket.data.guestId = undefined;
+    socket.data.isGuest = false;
+    next();
+  } catch (error) {
+    console.error('[socket.auth] failed to validate session cookie', error);
+    next(new Error('AUTH_UNAUTHORIZED'));
+  }
+}
+
+export async function attachOptionalChatIdentity(
+  socket: Socket,
+  next: (err?: Error) => void,
+): Promise<void> {
+  const cookieHeader = socket.handshake.headers.cookie;
+
+  if (!cookieHeader) {
+    next(new Error('AUTH_UNAUTHORIZED'));
+    return;
+  }
+
+  try {
+    const identity = await resolveIdentityFromSessionCookie(cookieHeader);
+
+    if (!identity) {
+      next(new Error('AUTH_UNAUTHORIZED'));
+      return;
+    }
+
+    socket.data.userId = identity.userId;
+    socket.data.username = identity.username;
+    socket.data.identityKey = identity.identityKey;
+    socket.data.guestId = identity.guestId;
+    socket.data.isGuest = identity.isGuest;
+    next();
+  } catch (error) {
+    console.error('[socket.auth] optional identity resolution failed', error);
+    next(new Error('AUTH_UNAUTHORIZED'));
+  }
+}

--- a/containers/socket/app/src/features/chat.socket.ts
+++ b/containers/socket/app/src/features/chat.socket.ts
@@ -4,6 +4,7 @@ import type { Namespace, Socket } from 'socket.io';
 import { ChatSendSchema } from '../contracts/sockets/chat/chat.schema';
 import type {
   ChatError,
+  ChatIdentity,
   ChatHistoryType,
   ChatMessage,
   ChatSystemMessage,
@@ -13,6 +14,7 @@ import type {
 
 const MAX_HISTORY = 50;
 const chatHistory: ChatHistoryType = [];
+const chatIdentityCounts = new Map<string, number>();
 
 const pushChatHistory = (message: ChatHistoryType[number]) => {
   chatHistory.push(message);
@@ -75,15 +77,41 @@ export function registerChatSocket(
   nsp: Namespace<ClientToServerChatEvents, ServerToClientChatEvents>,
 ) {
   nsp.on('connection', (socket: Socket<ClientToServerChatEvents, ServerToClientChatEvents>) => {
-    console.log('[Chat Socket] User connected:', socket.id);
+    const identityKey = socket.data.identityKey;
+    const username = socket.data.username;
+
+    if (typeof identityKey !== 'string' || identityKey.length === 0) {
+      socket.disconnect(true);
+      return;
+    }
+
+    if (typeof username !== 'string' || username.length === 0) {
+      socket.disconnect(true);
+      return;
+    }
+
+    const identity: ChatIdentity = {
+      identityKey,
+      username,
+      isGuest: socket.data.isGuest !== false,
+      ...(typeof socket.data.userId === 'string' ? { userId: socket.data.userId } : {}),
+    };
+
+    const previousCount = chatIdentityCounts.get(identityKey) ?? 0;
+    chatIdentityCounts.set(identityKey, previousCount + 1);
+
+    console.log('[Chat Socket] User connected:', username);
+    socket.emit('chat:identity', identity);
     socket.emit('chat:history', chatHistory.slice(-MAX_HISTORY));
-    socket.broadcast.emit('chat:system', systemMessage('USER_JOINED', socket.id));
+    if (previousCount === 0) {
+      socket.broadcast.emit('chat:system', systemMessage('USER_JOINED', username));
+    }
 
     socket.on('chat:send', (payload: unknown) => {
       const res = ChatSendSchema.safeParse(payload);
 
       if (res.success) {
-        socket.broadcast.emit('chat:message', chatMessage(socket.id, res.data.text));
+        socket.broadcast.emit('chat:message', chatMessage(username, res.data.text));
         return;
       }
 
@@ -91,7 +119,14 @@ export function registerChatSocket(
     });
 
     socket.on('disconnect', () => {
-      socket.broadcast.emit('chat:system', systemMessage('USER_LEFT', socket.id));
+      const nextCount = (chatIdentityCounts.get(identityKey) ?? 1) - 1;
+
+      if (nextCount <= 0) {
+        chatIdentityCounts.delete(identityKey);
+        socket.broadcast.emit('chat:system', systemMessage('USER_LEFT', username));
+      } else {
+        chatIdentityCounts.set(identityKey, nextCount);
+      }
     });
   });
 }

--- a/containers/socket/app/src/features/friends.socket.ts
+++ b/containers/socket/app/src/features/friends.socket.ts
@@ -1,39 +1,26 @@
-import type { Namespace, Server, Socket } from 'socket.io';
+import type { Namespace, Socket } from 'socket.io';
 
 let friendsNsp: Namespace | null = null;
 
 /** userId -> number of active /friends connections that identified as that user */
 const onlineCounts = new Map<string, number>();
 
-export function registerFriendsSocket(io: Server) {
-  const nsp = io.of('/friends');
+export function registerFriendsSocket(nsp: Namespace) {
   friendsNsp = nsp;
 
   nsp.on('connection', (socket: Socket) => {
-    let currentUserId: string | null = null;
+    const currentUserId = socket.data.userId;
 
-    socket.on('friends:identify', (userId: unknown) => {
-      if (typeof userId !== 'string' || userId.length === 0) return;
+    if (typeof currentUserId !== 'string' || currentUserId.length === 0) {
+      socket.disconnect(true);
+      return;
+    }
 
-      if (currentUserId === userId) {
-        void socket.join(`user:${userId}`);
-        return;
-      }
-
-      if (currentUserId) {
-        decrementOnline(currentUserId);
-      }
-
-      currentUserId = userId;
-      incrementOnline(userId);
-      void socket.join(`user:${userId}`);
-    });
+    incrementOnline(currentUserId);
+    void socket.join(`user:${currentUserId}`);
 
     socket.on('disconnect', () => {
-      if (currentUserId) {
-        decrementOnline(currentUserId);
-        currentUserId = null;
-      }
+      decrementOnline(currentUserId);
     });
   });
 }

--- a/containers/socket/app/src/index.ts
+++ b/containers/socket/app/src/index.ts
@@ -1,5 +1,7 @@
 import express from 'express';
-import { createServer } from 'http';
+import { existsSync, readFileSync } from 'fs';
+import { createServer as createHttpsServer } from 'https';
+import { join } from 'path';
 import { Server } from 'socket.io';
 
 import { handleInternalNotify, handlePresenceCheck } from './internal/notify.routes';
@@ -8,7 +10,30 @@ import { registerSockets } from './sockets/socket.register';
 const app = express();
 app.use(express.json());
 
-const httpServer = createServer(app);
+const certDir = process.env.CERT_DIR;
+
+function createAppServer() {
+  if (!certDir) {
+    throw new Error('CERT_DIR is required');
+  }
+
+  const certPath = join(certDir, 'localhost.crt');
+  const keyPath = join(certDir, 'localhost.key');
+
+  if (!existsSync(certPath) || !existsSync(keyPath)) {
+    throw new Error(`TLS certs not found in ${certDir}`);
+  }
+
+  return createHttpsServer(
+    {
+      cert: readFileSync(certPath),
+      key: readFileSync(keyPath),
+    },
+    app,
+  );
+}
+
+const httpServer = createAppServer();
 
 const io = new Server(httpServer, {
   cors: { origin: '*' },
@@ -20,5 +45,5 @@ app.post('/internal/notify', handleInternalNotify);
 app.post('/internal/presence', handlePresenceCheck);
 
 httpServer.listen(3100, () => {
-  console.log('Socket.IO server + internal notify on :3100');
+  console.log('Socket.IO server + internal notify on :3100 over HTTPS');
 });

--- a/containers/socket/app/src/sockets/socket.register.ts
+++ b/containers/socket/app/src/sockets/socket.register.ts
@@ -1,11 +1,20 @@
 import type { Server } from 'socket.io';
 
+import { attachOptionalChatIdentity, requireSessionSocketAuth } from '../auth/session-auth';
 import { registerFriendsSocket } from '../features/friends.socket';
 import { registerChatSocket } from '../features/chat.socket';
 import { registerRobotsSocket } from '../features/robots.socket';
 
 export function registerSockets(io: Server) {
-  registerFriendsSocket(io);
-  registerRobotsSocket(io.of('/robots'));
-  registerChatSocket(io.of('/chat'));
+  const friendsNsp = io.of('/friends');
+  const robotsNsp = io.of('/robots');
+  const chatNsp = io.of('/chat');
+
+  friendsNsp.use(requireSessionSocketAuth);
+  robotsNsp.use(requireSessionSocketAuth);
+  chatNsp.use(attachOptionalChatIdentity);
+
+  registerFriendsSocket(friendsNsp);
+  registerRobotsSocket(robotsNsp);
+  registerChatSocket(chatNsp);
 }

--- a/docs/FE-env-variables.md
+++ b/docs/FE-env-variables.md
@@ -73,22 +73,3 @@ Missing variables throw at startup using required helpers (fail fast strategy).
 
 ---
 
-## 5. Boolean Handling
-
-Environment variables are always strings.
-
-Example:
-
-```sh
-NEXT_PUBLIC_LOCALE_COOKIE_ENABLED=false
-```
-
-This is `"false"` (string), not `false` (boolean).
-
-Always parse explicitly:
-
-```ts
-value === "true";
-```
-
-Never rely on truthiness (`if (value)`), because `"false"` is truthy.

--- a/scripts/certs/README.md
+++ b/scripts/certs/README.md
@@ -24,6 +24,31 @@ Modern web apps often require HTTPS even in dev because of:
 
 - Improves development experience overrall
 
+## 🔐 Certificate Model: Local CA + Leaf Certificate
+
+This project now uses a **proper certificate chain** instead of a single self-signed cert:
+
+- **CA Certificate (`ca.pem`)**
+  - Acts as the trusted root authority
+  - `basicConstraints: CA:true`
+  - `keyUsage: keyCertSign, cRLSign`
+  - Valid for 10 years (3650 days)
+  - Trust this in your browser/OS
+
+- **Leaf Certificate (`localhost.crt`)**
+  - Server certificate for HTTPS serving
+  - `basicConstraints: CA:false`
+  - `keyUsage: digitalSignature, keyEncipherment`
+  - `extendedKeyUsage: serverAuth`
+  - Valid for 825 days
+  - Signed by the local CA
+
+**Why this matters:**
+- Follows proper TLS semantics: CA certs are for signing, leaf certs are for serving
+- Allows certificate rotation without re-trusting the CA
+- Aligns with production certificate best practices
+- Services only get `NODE_EXTRA_CA_CERTS=/certs/ca.pem` for trust validation
+
 ## Usage
 
 ### Generate the certificates (once)
@@ -60,13 +85,13 @@ Never share or submit to the repository your certificate key
 
 2. Custom -> Trusted certificates -> import
 
-4. Select the file at the root of this repo: localhost.crt
+3. Select the CA file at the root of this repo: ca.pem
 
-6. Click OK
+4. Click OK
 
-7. Close ALL Chrome windows
+5. Close ALL Chrome windows
 
-8. Reopen Chrome and visit:
+6. Reopen Chrome and visit:
 
    https://localhost:8443
 

--- a/scripts/certs/dev-certs.sh
+++ b/scripts/certs/dev-certs.sh
@@ -10,18 +10,20 @@ CERT_DIR="$ROOT_DIR/certs"
 
 CRT="$CERT_DIR/localhost.crt"
 KEY="$CERT_DIR/localhost.key"
+CA="$CERT_DIR/ca.pem"
 
-export CERT_DIR CRT KEY
+export CERT_DIR CRT KEY CA
 
 mkdir -p "$CERT_DIR"
 
 confirm_replace_certs_if_exist() {
-  if [ -f "$CRT" ] || [ -f "$KEY" ]; then
+  if [ -f "$CRT" ] || [ -f "$KEY" ] || [ -f "$CA" ]; then
 cat <<EOF
 
 Existing certificates detected:
-- Certificate: $(pwd)/$CRT
-- Private key:  $(pwd)/$KEY
+- CA certificate: $(pwd)/$CA
+- Certificate:    $(pwd)/$CRT
+- Private key:    $(pwd)/$KEY
 
 Do you want to replace them? [y/N]
 EOF
@@ -29,7 +31,7 @@ EOF
     case "$ans" in
       y|Y|yes|YES)
         echo "Replacing existing certificates..."
-        rm -f "$CRT" "$KEY"
+        rm -f "$CRT" "$KEY" "$CA"
         return 0
         ;;
       *)
@@ -50,13 +52,13 @@ Choose how HTTPS certificates should be generated:
 
   1) mkcert (needs testing)
      - Installs a local trusted CA
-     - No browser warnings
+     - Generates a leaf certificate signed by that CA
      - May require admin password
 
   2) Self-signed certificate (recommended)
+     - Creates a local CA and a separate leaf certificate
+     - Browser will show warning until the CA is trusted
      - No system changes
-     - Browser will show warning
-     - Can be trusted manually later
 
   3) Skip (I already have certificates)
 
@@ -96,5 +98,6 @@ esac
 
 echo
 echo "🎉 Certificates ready in: $CERT_DIR"
-echo "📄 Certificate: $(pwd)/$CRT"
-echo "🔑 Private key:  $(pwd)/$KEY"
+echo "📄 CA certificate:  $(pwd)/$CA"
+echo "📄 Certificate:     $(pwd)/$CRT"
+echo "🔑 Private key:     $(pwd)/$KEY"

--- a/scripts/certs/mkcert.sh
+++ b/scripts/certs/mkcert.sh
@@ -80,9 +80,11 @@ echo "🔧 Installing local CA (may prompt)..."
 
 mkcert -install
 
+cp "$(mkcert -CAROOT)/rootCA.pem" "$CERT_DIR/ca.pem"
+
 mkcert \
   -key-file "$KEY" \
   -cert-file "$CRT" \
-  localhost 127.0.0.1 ::1
+  localhost 127.0.0.1 ::1 backend socket frontend nginx
 
 echo "🎉 HTTPS ready with trusted mkcert certificate"

--- a/scripts/certs/mkcert.sh
+++ b/scripts/certs/mkcert.sh
@@ -80,7 +80,8 @@ echo "🔧 Installing local CA (may prompt)..."
 
 mkcert -install
 
-cp "$(mkcert -CAROOT)/rootCA.pem" "$CERT_DIR/ca.pem"
+mkcert_root="$(mkcert -CAROOT)"
+cp "$mkcert_root/rootCA.pem" "$CERT_DIR/ca.pem"
 
 mkcert \
   -key-file "$KEY" \

--- a/scripts/certs/selfsigned.sh
+++ b/scripts/certs/selfsigned.sh
@@ -3,7 +3,7 @@ set -eu
 
 has() { command -v "$1" >/dev/null 2>&1; }
 
-write_openssl_config() {
+write_ca_config() {
   file="$1"
   cat > "$file" <<'EOF'
 [req]
@@ -11,14 +11,41 @@ default_bits       = 2048
 prompt             = no
 default_md         = sha256
 distinguished_name = dn
-x509_extensions    = v3_req
+x509_extensions    = ca_ext
+
+[dn]
+CN = Local Development CA
+
+[ca_ext]
+basicConstraints = critical,CA:true,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+}
+
+write_server_config() {
+  file="$1"
+  cat > "$file" <<'EOF'
+[req]
+default_bits       = 2048
+prompt             = no
+default_md         = sha256
+distinguished_name = dn
+req_extensions     = server_req
 
 [dn]
 CN = localhost
 
-[v3_req]
-basicConstraints = critical,CA:TRUE
-keyUsage = critical, digitalSignature, keyEncipherment, keyCertSign
+[server_req]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[server_cert]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 
 [alt_names]
@@ -38,37 +65,95 @@ docker_ok() {
 }
 
 openssl_selfsigned_host() {
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' EXIT INT HUP TERM
   mkdir -p "$CERT_DIR"
-  config_file="$(mktemp)"
-  write_openssl_config "$config_file"
+  
+  ca_config="$temp_dir/ca.cnf"
+  write_ca_config "$ca_config"
+  
   openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "$temp_dir/ca.key" \
+    -out "$CERT_DIR/ca.pem" \
+    -days 3650 \
+    -config "$ca_config" \
+    -extensions ca_ext
+  
+  server_config="$temp_dir/server.cnf"
+  write_server_config "$server_config"
+  
+  openssl req -new -newkey rsa:2048 -nodes \
     -keyout "$KEY" \
+    -out "$temp_dir/localhost.csr" \
+    -subj "/CN=localhost" \
+    -config "$server_config" \
+    -extensions server_req
+  
+  openssl x509 -req \
+    -in "$temp_dir/localhost.csr" \
+    -CA "$CERT_DIR/ca.pem" \
+    -CAkey "$temp_dir/ca.key" \
+    -CAcreateserial \
     -out "$CRT" \
-    -days 365 \
-    -config "$config_file"
-  cp "$CRT" "$CERT_DIR/ca.pem"
-  rm -f "$config_file"
+    -days 825 \
+    -sha256 \
+    -extfile "$server_config" \
+    -extensions server_cert
+  
+  rm -f "$CERT_DIR/ca.srl"
+  trap - EXIT INT HUP TERM
 }
 
 openssl_selfsigned_docker() {
   mkdir -p "$CERT_DIR"
-  docker run --rm -v "$CERT_DIR:/out" alpine:3.19 sh -c '
+  docker run --rm -v "$CERT_DIR:/out" alpine:3.19 sh -ceu '
     apk add --no-cache openssl >/dev/null
 
-    cat > /tmp/localhost.cnf <<EOF
+    cat > /tmp/ca.cnf <<EOF
 [req]
 default_bits       = 2048
 prompt             = no
 default_md         = sha256
 distinguished_name = dn
-x509_extensions    = v3_req
+x509_extensions    = ca_ext
+
+[dn]
+CN = Local Development CA
+
+[ca_ext]
+basicConstraints = critical,CA:true,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+    openssl req -x509 -newkey rsa:2048 -nodes \
+      -keyout /tmp/ca.key \
+      -out /out/ca.pem \
+      -days 3650 \
+      -config /tmp/ca.cnf \
+      -extensions ca_ext
+
+    cat > /tmp/server.cnf <<EOF
+[req]
+default_bits       = 2048
+prompt             = no
+default_md         = sha256
+distinguished_name = dn
+req_extensions     = server_req
 
 [dn]
 CN = localhost
 
-[v3_req]
-basicConstraints = critical,CA:TRUE
-keyUsage = critical, digitalSignature, keyEncipherment, keyCertSign
+[server_req]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[server_cert]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 
 [alt_names]
@@ -81,19 +166,31 @@ IP.1  = 127.0.0.1
 IP.2  = ::1
 EOF
 
-    openssl req -x509 -newkey rsa:2048 -nodes \
+    openssl req -new -newkey rsa:2048 -nodes \
       -keyout /out/localhost.key \
-      -out /out/localhost.crt \
-      -days 365 \
-      -config /tmp/localhost.cnf
+      -out /tmp/localhost.csr \
+      -subj "/CN=localhost" \
+      -config /tmp/server.cnf \
+      -extensions server_req
 
-    cp /out/localhost.crt /out/ca.pem
+    openssl x509 -req \
+      -in /tmp/localhost.csr \
+      -CA /out/ca.pem \
+      -CAkey /tmp/ca.key \
+      -CAcreateserial \
+      -out /out/localhost.crt \
+      -days 825 \
+      -sha256 \
+      -extfile /tmp/server.cnf \
+      -extensions server_cert
+
+    rm -f /out/ca.srl
   '
 }
 echo "➡️ Using self-signed certificate..."
 
 if docker_ok; then
-  echo "✅ Docker available → generating cert with Docker"
+  echo "✅ Docker available → generating CA and leaf cert with Docker"
   openssl_selfsigned_docker
 elif has openssl; then
   echo "⚠️ Docker not available → using host openssl"
@@ -118,13 +215,13 @@ EOF
 fi
 
 cat << EOF
-✅ Self-signed cert created
-📄 Certificate: $(pwd)/$CRT
-🔑 Private key:  $(pwd)/$KEY
+✅ Self-signed cert chain created
+📄 CA certificate:   $(pwd)/$CERT_DIR/ca.pem
+📄 Server certificate: $(pwd)/$CRT
+🔑 Server private key: $(pwd)/$KEY
 
-
-⚠️  Note: Your browser will show a warning for self-signed certificates.
-    You can choose to trust the certificate manually in your browser.
+⚠️  Trust the CA certificate, not the server certificate, in your browser or OS store.
+    The server cert is signed by the local CA and is only meant for HTTPS serving.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🔐 Chrome Certificate Setup (UI Method)
@@ -136,9 +233,9 @@ cat << EOF
 
 2. Custom -> Trusted certificates -> import
 
-4. Select the file at the root of this repo: localhost.crt
+3. Select the CA file at the root of this repo: ca.pem
 
-6. Click OK
+4. Click OK
 
 7. Close ALL Chrome windows
 

--- a/scripts/certs/selfsigned.sh
+++ b/scripts/certs/selfsigned.sh
@@ -3,6 +3,35 @@ set -eu
 
 has() { command -v "$1" >/dev/null 2>&1; }
 
+write_openssl_config() {
+  file="$1"
+  cat > "$file" <<'EOF'
+[req]
+default_bits       = 2048
+prompt             = no
+default_md         = sha256
+distinguished_name = dn
+x509_extensions    = v3_req
+
+[dn]
+CN = localhost
+
+[v3_req]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical, digitalSignature, keyEncipherment, keyCertSign
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+DNS.2 = backend
+DNS.3 = socket
+DNS.4 = frontend
+DNS.5 = nginx
+IP.1  = 127.0.0.1
+IP.2  = ::1
+EOF
+}
+
 docker_ok() {
   has docker || return 1
   docker info >/dev/null 2>&1
@@ -10,11 +39,15 @@ docker_ok() {
 
 openssl_selfsigned_host() {
   mkdir -p "$CERT_DIR"
+  config_file="$(mktemp)"
+  write_openssl_config "$config_file"
   openssl req -x509 -newkey rsa:2048 -nodes \
     -keyout "$KEY" \
     -out "$CRT" \
     -days 365 \
-    -subj "/CN=localhost"
+    -config "$config_file"
+  cp "$CRT" "$CERT_DIR/ca.pem"
+  rm -f "$config_file"
 }
 
 openssl_selfsigned_docker() {
@@ -34,10 +67,16 @@ x509_extensions    = v3_req
 CN = localhost
 
 [v3_req]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical, digitalSignature, keyEncipherment, keyCertSign
 subjectAltName = @alt_names
 
 [alt_names]
 DNS.1 = localhost
+DNS.2 = backend
+DNS.3 = socket
+DNS.4 = frontend
+DNS.5 = nginx
 IP.1  = 127.0.0.1
 IP.2  = ::1
 EOF
@@ -47,6 +86,8 @@ EOF
       -out /out/localhost.crt \
       -days 365 \
       -config /tmp/localhost.cnf
+
+    cp /out/localhost.crt /out/ca.pem
   '
 }
 echo "➡️ Using self-signed certificate..."

--- a/scripts/env/setup-env.sh
+++ b/scripts/env/setup-env.sh
@@ -224,6 +224,7 @@ set_env_var "$BACKEND_ENV" "REDIS_HOST" "redis"
 set_env_var "$BACKEND_ENV" "REDIS_PORT" "6379"
 set_env_var "$BACKEND_ENV" "REDIS_URL" "redis://redis:6379"
 set_env_var "$BACKEND_ENV" "SESSION_TTL" "604800000"
+set_env_var "$BACKEND_ENV" "NODE_EXTRA_CA_CERTS" "/certs/ca.pem"
 
 set_env_var "$BACKEND_ENV" "SOCKET_SERVICE_URL" "https://socket:3100"
 set_env_var "$BACKEND_ENV" "CERT_DIR" "/certs"
@@ -274,6 +275,8 @@ echo
 
 print_section_if_empty "$FRONTEND_ENV" "Frontend environment"
 
+set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_SOCKET_URL" "https://localhost:8443"
+set_env_var "$FRONTEND_ENV" "NODE_EXTRA_CA_CERTS" "/certs/ca.pem"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_APP_URL" "https://localhost:8443"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_API_BASE_URL" "/api"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_SOCKET_URL" "https://localhost:8443"

--- a/scripts/env/setup-env.sh
+++ b/scripts/env/setup-env.sh
@@ -225,7 +225,9 @@ set_env_var "$BACKEND_ENV" "REDIS_PORT" "6379"
 set_env_var "$BACKEND_ENV" "REDIS_URL" "redis://redis:6379"
 set_env_var "$BACKEND_ENV" "SESSION_TTL" "604800000"
 
-set_env_var "$BACKEND_ENV" "SOCKET_SERVICE_URL" "http://socket:3100"
+set_env_var "$BACKEND_ENV" "SOCKET_SERVICE_URL" "https://socket:3100"
+set_env_var "$BACKEND_ENV" "CERT_DIR" "/certs"
+set_env_var "$BACKEND_ENV" "NODE_EXTRA_CA_CERTS" "/certs/ca.pem"
 append_if_missing "$BACKEND_ENV" "SOCKET_INTERNAL_SECRET" ""
 
 current_google="$(get_env_value "$BACKEND_ENV" "GOOGLE_CLIENT_ID")"
@@ -277,7 +279,8 @@ set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_API_BASE_URL" "/api"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_SOCKET_URL" "https://localhost:8443"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_LOCALE_COOKIE_NAME" "locale"
 set_env_var "$FRONTEND_ENV" "NODE_ENV" "development"
-set_env_var "$FRONTEND_ENV" "API_BASE_URL" "http://backend:4000"
+set_env_var "$FRONTEND_ENV" "API_BASE_URL" "https://backend:4000"
+set_env_var "$FRONTEND_ENV" "NODE_EXTRA_CA_CERTS" "/certs/ca.pem"
 
 echo
 echo "✅ Environment setup complete."

--- a/scripts/env/setup-env.sh
+++ b/scripts/env/setup-env.sh
@@ -274,6 +274,7 @@ print_section_if_empty "$FRONTEND_ENV" "Frontend environment"
 
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_APP_URL" "https://localhost:8443"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_API_BASE_URL" "/api"
+set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_SOCKET_URL" "https://localhost:8443"
 set_env_var "$FRONTEND_ENV" "NEXT_PUBLIC_LOCALE_COOKIE_NAME" "locale"
 set_env_var "$FRONTEND_ENV" "NODE_ENV" "development"
 set_env_var "$FRONTEND_ENV" "API_BASE_URL" "http://backend:4000"


### PR DESCRIPTION
This pull request introduces HTTPS support across the backend, frontend, and socket services, and adds a new guest session/identity feature to the authentication system. It also updates service communication and configuration to use secure connections and propagates identity data to the chat system. Below are the most important changes:

**HTTPS Enablement and Configuration**

* The backend server (`index.ts`) now requires TLS certificates and starts as an HTTPS server, ensuring all API traffic is encrypted. Docker Compose and health checks are updated to use HTTPS and CA certificates for all services (`docker-compose.yml`). [[1]](diffhunk://#diff-54b5825ed5174a81934376b9bc622b09a0aa518194289ed38205a210a186ec0eR3-R32) [[2]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L34-R45) [[3]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291R64-R78) [[4]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L85-R121)
* Scripts and smoke tests are updated to use HTTPS endpoints and CA certificates by default, ensuring local development and tests also use secure communication (`curl-command.sh`, `smoke-friendships.mjs`, `smoke.config.ts`). [[1]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L3-R5) [[2]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L17-R18) [[3]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L31-R32) [[4]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L46-R47) [[5]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L56-R57) [[6]](diffhunk://#diff-a312de3539e0560cb155f542b37093239b471c23c4d1b7c2c86eadf81810f654L4-R7) [[7]](diffhunk://#diff-c47edaeb4fea80e5cfab73f3124e4390a4df8f17e932c23d2afa4dccac1f4e43L1-R1)
* Socket and friendship services are reconfigured to use `https://` URLs for inter-service communication (`friendships.notify.ts`, `friendships.presence.ts`, `docker-compose.yml`). [[1]](diffhunk://#diff-95f583949707d37d6b1d02e5bc16bbb639acd1c5f8a8763b93087a9a7902fbb3L1-R1) [[2]](diffhunk://#diff-c8cd35ba4ae6dcdc2769ad2a9fb5d37fb4086a3a3c010ff57a8dc6cfb65b9110L1-R1) [[3]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L34-R45) [[4]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L85-R121)

**Guest Session and Identity Management**

* Adds new endpoints to the authentication controller for creating and retrieving guest sessions/identities. Guest users are assigned a unique `guestId` and username, which are stored in the session and propagated to the client (`local.controller.ts`, `local.routes.ts`). [[1]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR2-R10) [[2]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR35-R76) [[3]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR95-R183) [[4]](diffhunk://#diff-0c041cd9e72d2e9d3a603f60298f32f2488654100d8ef02ffed64b9d6bf4020fL12-R18) [[5]](diffhunk://#diff-0c041cd9e72d2e9d3a603f60298f32f2488654100d8ef02ffed64b9d6bf4020fR31-R32)
* Ensures that after a user logs in or verifies email, any guest session data is cleared from the session to prevent identity confusion (`local.controller.ts`, `oauth.controller.ts`, `verification.controller.ts`). [[1]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR95-R183) [[2]](diffhunk://#diff-859fda5d9f30111f73680309f88f2340efe9f2c4be5d0be59a9fd7c23086191cR39-R40) [[3]](diffhunk://#diff-8a2b544b9ee64adffdf7679ce3e3c1ec446deb1f8e63ca0136fba1a33e3ca0ebR63-R64)

**Chat System Identity Propagation**

* Adds a new `chat:identity` event and schema to the chat socket contract, allowing the server to inform the client of the current user's identity (including guest status) (`chat.schema.ts`). [[1]](diffhunk://#diff-e9ec51e1a5b06811f73833751eb3692d6c6ba5e95bde5849c112001ffff0f333R21) [[2]](diffhunk://#diff-e9ec51e1a5b06811f73833751eb3692d6c6ba5e95bde5849c112001ffff0f333R112-R120)
* Updates the frontend chat provider to handle the new identity event, correctly formatting chat messages based on the user's identity, and removes now-unnecessary message formatting hacks (`chat.provider.tsx`). [[1]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4R17) [[2]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4L38-R45) [[3]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4L67-R75) [[4]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4L79-R93)

**Frontend HTTPS Support**

* The frontend development server is configured to run over HTTPS with the appropriate certificates, aligning with the rest of the stack (`package.json`).

(References: [[1]](diffhunk://#diff-54b5825ed5174a81934376b9bc622b09a0aa518194289ed38205a210a186ec0eR3-R32) [[2]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L34-R45) [[3]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291R64-R78) [[4]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L85-R121) [[5]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L3-R5) [[6]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L17-R18) [[7]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L31-R32) [[8]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L46-R47) [[9]](diffhunk://#diff-50665e4e7b2e4fca3e67ceba568da1e3d5701bd3fc04bf20bf61b0fcad381058L56-R57) [[10]](diffhunk://#diff-a312de3539e0560cb155f542b37093239b471c23c4d1b7c2c86eadf81810f654L4-R7) [[11]](diffhunk://#diff-c47edaeb4fea80e5cfab73f3124e4390a4df8f17e932c23d2afa4dccac1f4e43L1-R1) [[12]](diffhunk://#diff-95f583949707d37d6b1d02e5bc16bbb639acd1c5f8a8763b93087a9a7902fbb3L1-R1) [[13]](diffhunk://#diff-c8cd35ba4ae6dcdc2769ad2a9fb5d37fb4086a3a3c010ff57a8dc6cfb65b9110L1-R1) [[14]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR2-R10) [[15]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR35-R76) [[16]](diffhunk://#diff-31a7aef4e13a0c3e55ec9c5eb326b8e0507b2ab2b772a898af2ce185594762ffR95-R183) [[17]](diffhunk://#diff-0c041cd9e72d2e9d3a603f60298f32f2488654100d8ef02ffed64b9d6bf4020fL12-R18) [[18]](diffhunk://#diff-0c041cd9e72d2e9d3a603f60298f32f2488654100d8ef02ffed64b9d6bf4020fR31-R32) [[19]](diffhunk://#diff-859fda5d9f30111f73680309f88f2340efe9f2c4be5d0be59a9fd7c23086191cR39-R40) [[20]](diffhunk://#diff-8a2b544b9ee64adffdf7679ce3e3c1ec446deb1f8e63ca0136fba1a33e3ca0ebR63-R64) [[21]](diffhunk://#diff-e9ec51e1a5b06811f73833751eb3692d6c6ba5e95bde5849c112001ffff0f333R21) [[22]](diffhunk://#diff-e9ec51e1a5b06811f73833751eb3692d6c6ba5e95bde5849c112001ffff0f333R112-R120) [[23]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4R17) [[24]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4L38-R45) [[25]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4L67-R75) [[26]](diffhunk://#diff-02b023aa0bbd051d7fd868714a6119b88c098a42f737cbdb9fe78b498f983fe4L79-R93) [[27]](diffhunk://#diff-1ce5c73553a9126bf9986711b0fa6acd24282d9d713096a100a1bfae8b7451aeL7-R7)