### PR TITLE
feat(users): implement user search endpoint (#175)

### DIFF
--- a/containers/backend/app/docs/openapi.yaml
+++ b/containers/backend/app/docs/openapi.yaml
@@ -431,14 +431,20 @@ paths:
     get:
       tags: [Users]
       summary: Search users by partial username
+      description: >
+        Case-insensitive partial match on username. Requires authentication.
+        Excludes the requesting user. Exact matches are ranked first.
+        Rate limited to 10 requests per 10 seconds per user.
       operationId: searchUsers
+      security:
+        - cookieAuth: []
       parameters:
         - in: query
           name: q
           required: true
           schema:
             type: string
-            minLength: 1
+            minLength: 2
         - in: query
           name: limit
           required: false
@@ -446,19 +452,32 @@ paths:
             type: integer
             minimum: 1
             maximum: 20
+            default: 20
       responses:
         '200':
-          description: Matching users
+          description: Matching users with friendship context
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchUsersResponse'
+        '401':
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
         '422':
           description: Validation error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
         '500':
           description: Internal error
           content:
@@ -993,6 +1012,29 @@ components:
                   type: integer
                 count:
                   type: integer
+    SearchUserResult:
+      type: object
+      required: [id, username, avatar, friendshipStatus, senderId, friendshipId]
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        avatar:
+          type: string
+          nullable: true
+        friendshipStatus:
+          type: string
+          enum: [none, pending, accepted]
+        senderId:
+          type: string
+          format: uuid
+          nullable: true
+        friendshipId:
+          type: string
+          format: uuid
+          nullable: true
     SearchUsersResponse:
       type: object
       required: [ok, data]
@@ -1007,7 +1049,7 @@ components:
             users:
               type: array
               items:
-                $ref: '#/components/schemas/UserPublic'
+                $ref: '#/components/schemas/SearchUserResult'
     FriendshipPublic:
       type: object
       required: [id, friendUserId, friendUsername, friendAvatar, status, isSender, createdAt]

--- a/containers/backend/app/src/friendships/friendships.repo.ts
+++ b/containers/backend/app/src/friendships/friendships.repo.ts
@@ -309,13 +309,13 @@ export async function acceptFriendRequest(
 export async function findFriendshipsByUserPairs(
   currentUserId: string,
   otherUserIds: string[],
-): Promise<Map<string, { id: string; status: 'pending' | 'accepted'; senderId: string }>> {
+): Promise<Map<string, FriendshipPairRow>> {
   if (otherUserIds.length === 0) return new Map();
 
   const rows = await prisma.friendship.findMany({
     where: {
       OR: otherUserIds.map((otherId) => {
-        const [u1, u2] = currentUserId < otherId ? [currentUserId, otherId] : [otherId, currentUserId];
+        const [u1, u2] = sortedPair(currentUserId, otherId);
         return { userId1: u1, userId2: u2 };
       }),
     },
@@ -328,7 +328,7 @@ export async function findFriendshipsByUserPairs(
     },
   });
 
-  const map = new Map<string, { id: string; status: 'pending' | 'accepted'; senderId: string }>();
+  const map = new Map<string, FriendshipPairRow>();
   for (const row of rows) {
     const otherId = row.userId1 === currentUserId ? row.userId2 : row.userId1;
     map.set(otherId, { id: row.id, status: row.status, senderId: row.senderId });

--- a/containers/backend/app/src/friendships/friendships.repo.ts
+++ b/containers/backend/app/src/friendships/friendships.repo.ts
@@ -301,6 +301,42 @@ export async function acceptFriendRequest(
   return toPublic(updated as FriendshipRow, userId);
 }
 
+/**
+ * Batch lookup: returns a Map<otherUserId, {id, status, senderId}> for
+ * all friendships between currentUserId and each of otherUserIds.
+ * Used by the user search endpoint to inject friendship context in O(1).
+ */
+export async function findFriendshipsByUserPairs(
+  currentUserId: string,
+  otherUserIds: string[],
+): Promise<Map<string, { id: string; status: 'pending' | 'accepted'; senderId: string }>> {
+  if (otherUserIds.length === 0) return new Map();
+
+  const rows = await prisma.friendship.findMany({
+    where: {
+      OR: otherUserIds.map((otherId) => {
+        const [u1, u2] = currentUserId < otherId ? [currentUserId, otherId] : [otherId, currentUserId];
+        return { userId1: u1, userId2: u2 };
+      }),
+    },
+    select: {
+      id: true,
+      userId1: true,
+      userId2: true,
+      status: true,
+      senderId: true,
+    },
+  });
+
+  const map = new Map<string, { id: string; status: 'pending' | 'accepted'; senderId: string }>();
+  for (const row of rows) {
+    const otherId = row.userId1 === currentUserId ? row.userId2 : row.userId1;
+    map.set(otherId, { id: row.id, status: row.status, senderId: row.senderId });
+  }
+
+  return map;
+}
+
 export async function findUserById(userId: string): Promise<boolean> {
   const user = await prisma.user.findUnique({
     where: { id: userId },

--- a/containers/backend/app/src/users/users.controllers.ts
+++ b/containers/backend/app/src/users/users.controllers.ts
@@ -50,6 +50,7 @@ export async function searchUsersController(
   res: Response<SearchUsersResponse, { query: SearchUsersQuery }>,
 ): Promise<void> {
   const { q, limit } = res.locals.query;
-  const results = await searchUsers(q, limit);
+  const currentUserId = req.session.userId!;
+  const results = await searchUsers(q, limit, currentUserId);
   res.status(200).json({ ok: true, data: { users: results } });
 }

--- a/containers/backend/app/src/users/users.repo.ts
+++ b/containers/backend/app/src/users/users.repo.ts
@@ -6,6 +6,12 @@ type UserPublicRow = {
   username: string;
 };
 
+type UserSearchRow = {
+  id: string;
+  username: string;
+  avatar: string | null;
+};
+
 function mapUserRow(row: UserPublicRow): UserPublic {
   return {
     id: row.id,
@@ -49,17 +55,23 @@ export async function selectUserDataByUsername(username: string): Promise<UserPu
   return row ? mapUserRow(row) : null;
 }
 
-export async function searchUsersByUsername(query: string, limit: number): Promise<UserPublic[]> {
-  const rows = await prisma.user.findMany({
-    where: {
-      username: {
-        contains: query,
-        mode: 'insensitive',
-      },
-    },
-    select: userPublicSelect,
-    take: limit,
-  });
+export async function searchUsersByUsername(
+  query: string,
+  limit: number,
+  currentUserId: string,
+): Promise<UserSearchRow[]> {
+  const sanitized = query.replace(/[%_\\]/g, '\\$&');
 
-  return rows.map(mapUserRow);
+  const rows = await prisma.$queryRaw<UserSearchRow[]>`
+    SELECT id, username, avatar
+    FROM users
+    WHERE username ILIKE ${'%' + sanitized + '%'}
+      AND id != ${currentUserId}::uuid
+    ORDER BY
+      CASE WHEN username ILIKE ${sanitized} THEN 0 ELSE 1 END,
+      username ASC
+    LIMIT ${limit}
+  `;
+
+  return rows;
 }

--- a/containers/backend/app/src/users/users.routes.ts
+++ b/containers/backend/app/src/users/users.routes.ts
@@ -1,9 +1,18 @@
 import { Router } from 'express';
 
-import { validateQuery, validateParams } from '@shared';
+import { validateQuery, validateParams, requireAuth, ApiError } from '@shared';
+import { createRateLimit } from '@shared/rate-limit';
 import { GetUserByIdParamSchema, GetUsersQuerySchema, SearchUsersQuerySchema } from '@contracts/users/users.validation';
 
 import { getUsersController, getUserById, getUserByUsername, searchUsersController } from './users.controllers';
+
+const searchRateLimit = createRateLimit({
+  keyPrefix: 'rl:users:search',
+  max: 10,
+  windowMs: 10_000,
+  extractRaw: (req) => req.session?.userId,
+  onLimitExceeded: () => new ApiError('AUTH_RATE_LIMITED'),
+});
 
 export const usersRouter = Router();
 
@@ -11,6 +20,6 @@ export const usersRouter = Router();
 // GET /api/users?limit=20&offset=0
 // ---------------------------------------
 usersRouter.get('/', validateQuery(GetUsersQuerySchema), getUsersController);
-usersRouter.get('/search', validateQuery(SearchUsersQuerySchema), searchUsersController);
+usersRouter.get('/search', requireAuth, searchRateLimit, validateQuery(SearchUsersQuerySchema), searchUsersController);
 usersRouter.get('/username/:username', getUserByUsername);
 usersRouter.get('/:userId', validateParams(GetUserByIdParamSchema), getUserById);

--- a/containers/backend/app/src/users/users.service.ts
+++ b/containers/backend/app/src/users/users.service.ts
@@ -1,7 +1,8 @@
-import type { UserPublic } from '@contracts/users/users.contracts';
+import type { UserPublic, SearchUserResult } from '@contracts/users/users.contracts';
 import { ApiError } from '@shared';
 
 import { listUsers, selectUserData, selectUserDataByUsername, searchUsersByUsername } from './users.repo';
+import { findFriendshipsByUserPairs } from '../friendships/friendships.repo';
 
 type getUsersProps = {
   limit: number;
@@ -26,6 +27,27 @@ export async function userByUsername(username: string): Promise<UserPublic> {
   return data;
 }
 
-export async function searchUsers(query: string, limit: number): Promise<UserPublic[]> {
-  return await searchUsersByUsername(query, limit);
+export async function searchUsers(
+  query: string,
+  limit: number,
+  currentUserId: string,
+): Promise<SearchUserResult[]> {
+  const users = await searchUsersByUsername(query, limit, currentUserId);
+
+  if (users.length === 0) return [];
+
+  const otherUserIds = users.map((u) => u.id);
+  const friendshipMap = await findFriendshipsByUserPairs(currentUserId, otherUserIds);
+
+  return users.map((u) => {
+    const friendship = friendshipMap.get(u.id);
+    return {
+      id: u.id,
+      username: u.username,
+      avatar: u.avatar,
+      friendshipStatus: friendship ? friendship.status : 'none',
+      senderId: friendship ? friendship.senderId : null,
+      friendshipId: friendship ? friendship.id : null,
+    };
+  });
 }

--- a/containers/contracts/api/users/users.contracts.ts
+++ b/containers/contracts/api/users/users.contracts.ts
@@ -34,8 +34,17 @@ export type UsersListError = (typeof USERS_LIST_ERRORS)[number];
 
 export type UsersListResponse = ApiResponse<UsersListOk, UsersListError, ValidationErrorDetails>;
 
+export type SearchUserResult = {
+  id: string;
+  username: string;
+  avatar: string | null;
+  friendshipStatus: 'none' | 'pending' | 'accepted';
+  senderId: string | null;
+  friendshipId: string | null;
+};
+
 export type SearchUsersOk = {
-  users: UserPublic[];
+  users: SearchUserResult[];
 };
 
 export type SearchUsersResponse = ApiResponse<SearchUsersOk, UsersErrorName, ValidationErrorDetails>;

--- a/containers/contracts/api/users/users.contracts.ts
+++ b/containers/contracts/api/users/users.contracts.ts
@@ -1,6 +1,6 @@
 import type { ApiResponse } from '../http/response';
 import type { ValidationErrorDetails } from '../http/validation';
-import type { UsersErrorName } from './users.errors'; // create this like auth.errors
+import type { UsersErrorName, SearchUsersErrorName } from './users.errors';
 
 export type UserPublic = {
   id: string; // uuid zod can check for it on validation
@@ -47,6 +47,6 @@ export type SearchUsersOk = {
   users: SearchUserResult[];
 };
 
-export type SearchUsersResponse = ApiResponse<SearchUsersOk, UsersErrorName, ValidationErrorDetails>;
+export type SearchUsersResponse = ApiResponse<SearchUsersOk, SearchUsersErrorName, ValidationErrorDetails>;
 
 export type UserPublicResponse = ApiResponse<UserPublic, UsersListError, ValidationErrorDetails>;

--- a/containers/contracts/api/users/users.errors.ts
+++ b/containers/contracts/api/users/users.errors.ts
@@ -4,8 +4,19 @@ import { VALIDATION_ERROR } from '../http';
 export const USERS_ERRORS = {
   INTERNAL_ERROR: HttpStatus.INTERNAL_SERVER_ERROR,
   USER_NOT_FOUND: HttpStatus.NOT_FOUND,
+  AUTH_UNAUTHORIZED: HttpStatus.UNAUTHORIZED,
+  AUTH_RATE_LIMITED: HttpStatus.TOO_MANY_REQUESTS,
   ...VALIDATION_ERROR,
 } as const;
 
 export type UsersErrorName = keyof typeof USERS_ERRORS;
 export type UsersErrorCode = (typeof USERS_ERRORS)[UsersErrorName];
+
+export const SEARCH_USERS_ERRORS = [
+  'INTERNAL_ERROR',
+  'VALIDATION_ERROR',
+  'AUTH_UNAUTHORIZED',
+  'AUTH_RATE_LIMITED',
+] as const satisfies readonly UsersErrorName[];
+
+export type SearchUsersErrorName = (typeof SEARCH_USERS_ERRORS)[number];

--- a/containers/contracts/api/users/users.validation.ts
+++ b/containers/contracts/api/users/users.validation.ts
@@ -43,7 +43,11 @@ export const GetUserByIdParamSchema = z.strictObject({
 
 export const SearchUsersQuerySchema = z
   .object({
-    q: z.string().trim().min(1, { message: VALIDATION.REQUIRED }).max(100, { message: VALIDATION.FIELD_TOO_LONG }),
+    q: z
+      .string()
+      .trim()
+      .min(2, { message: VALIDATION.FIELD_TOO_SHORT })
+      .max(100, { message: VALIDATION.FIELD_TOO_LONG }),
     limit: intFromQuery(VALIDATION.INVALID_FORMAT).optional(),
   })
   .strict()
@@ -51,7 +55,7 @@ export const SearchUsersQuerySchema = z
     q: q.q,
     limit: q.limit ?? 20,
   }))
-  .refine((q) => q.limit >= 1 && q.limit <= 50, {
+  .refine((q) => q.limit >= 1 && q.limit <= 20, {
     message: VALIDATION.OUT_OF_RANGE,
     path: ['limit'],
   });

--- a/containers/contracts/api/users/users.validation.ts
+++ b/containers/contracts/api/users/users.validation.ts
@@ -46,6 +46,7 @@ export const SearchUsersQuerySchema = z
     q: z
       .string()
       .trim()
+      .min(1, { message: VALIDATION.REQUIRED })
       .min(2, { message: VALIDATION.FIELD_TOO_SHORT })
       .max(100, { message: VALIDATION.FIELD_TOO_LONG }),
     limit: intFromQuery(VALIDATION.INVALID_FORMAT).optional(),


### PR DESCRIPTION
Add GET /users/search with auth, self-exclusion, friendship context, rate limiting (10 req/10s), exact-match prioritization, and min 2 chars.

- Add SearchUserResult type with avatar and friendship context fields
- Refactor searchUsersByUsername with  for avatar, exclusion, and exact-match ordering
- Add findFriendshipsByUserPairs batch lookup in friendships.repo.ts
- Refactor searchUsers service to inject friendship context per result
- Add requireAuth + createRateLimit(10/10s) middleware to /search route
- Update OpenAPI spec with SearchUserResult schema and new responses