### PR TITLE
246 - Game in navbar

### DIFF
--- a/containers/frontend/web/src/features/navigation/navigation.config.ts
+++ b/containers/frontend/web/src/features/navigation/navigation.config.ts
@@ -11,7 +11,7 @@ export type NavItem = {
 };
 const baseNavItems: NavItem[] = [
   { href: '/', key: 'home', exact: true, icon: 'home' },
-  { href: '/robots', key: 'robots', exact: false, icon: 'gamepad' },
+  { href: '/game', key: 'game', exact: false, icon: 'gamepad' },
   { href: '/ui', key: 'ui', exact: false, icon: 'ui' },
 ];
 

--- a/containers/frontend/web/src/i18n/messages/ca.json
+++ b/containers/frontend/web/src/i18n/messages/ca.json
@@ -378,7 +378,7 @@
       "menu": "Menú",
       "mainAriaLabel": "Navegació principal",
       "ui": "UI",
-      "robots": "Robots",
+      "game": "Joc",
       "profile": "Perfil",
       "logout": "Tancar sessió",
       "settings": "Configuració"

--- a/containers/frontend/web/src/i18n/messages/en.d.json.ts
+++ b/containers/frontend/web/src/i18n/messages/en.d.json.ts
@@ -380,7 +380,7 @@ declare const messages: {
       "menu": "Menu",
       "mainAriaLabel": "Main navigation",
       "ui": "UI",
-      "robots": "Robots",
+      "game": "Game",
       "profile": "Profile",
       "logout": "Logout",
       "settings": "Settings"

--- a/containers/frontend/web/src/i18n/messages/en.json
+++ b/containers/frontend/web/src/i18n/messages/en.json
@@ -377,7 +377,7 @@
       "menu": "Menu",
       "mainAriaLabel": "Main navigation",
       "ui": "UI",
-      "robots": "Robots",
+      "game": "Game",
       "profile": "Profile",
       "logout": "Logout",
       "settings": "Settings"

--- a/containers/frontend/web/src/i18n/messages/es.json
+++ b/containers/frontend/web/src/i18n/messages/es.json
@@ -377,7 +377,7 @@
       "menu": "Menú",
       "mainAriaLabel": "Navegación principal",
       "ui": "UI",
-      "robots": "Robots",
+      "game": "Juego",
       "profile": "Perfil",
       "logout": "Cerrar sesión",
       "settings": "Configuración"


### PR DESCRIPTION
This pull request updates navigation and internationalization to replace the "Robots" menu item with "Game" throughout the application. The main changes include updating the navigation route and all related translations.

**Navigation update:**
* Changed the navigation route from `/robots` to `/game` and updated the associated key and icon in `navigation.config.ts`.

**Internationalization updates:**
* Updated the menu label from "Robots" to "Game" in the English translation files (`en.json`, `en.d.json.ts`). [[1]](diffhunk://#diff-d497c44fd8285d9639426f39448fcc2874c8d4deeb8355a69670dfe4aaf7eb01L380-R380) [[2]](diffhunk://#diff-2bb09279f63bb715df59bef2965b5704d72cdc4ddd0f80fa1850ccd058600359L383-R383)
* Updated the menu label from "Robots" to "Juego" in the Spanish translation file (`es.json`).
* Updated the menu label from "Robots" to "Joc" in the Catalan translation file (`ca.json`).