### PR TITLE
258 auth typecheck fixes

### DIFF
--- a/containers/contracts/api/auth/auth.contract.ts
+++ b/containers/contracts/api/auth/auth.contract.ts
@@ -68,15 +68,17 @@ export type ResendVerificationOk = null;
 
 export const AUTH_RESEND_VERIFICATION_ERRORS = [
   'AUTH_RATE_LIMITED',
-  'AUTH_RESEND_VERIFICATION_NOT_FOUND',
-  'AUTH_RESEND_VERIFICATION_COOLDOWN',
   'AUTH_INTERNAL_ERROR',
   'VALIDATION_ERROR',
 ] as const satisfies readonly AuthErrorName[];
 
 export type ResendVerificationError = (typeof AUTH_RESEND_VERIFICATION_ERRORS)[number];
 
-export type ResendVerificationRes = ApiResponse<ResendVerificationOk, ResendVerificationError>;
+export type ResendVerificationRes = ApiResponse<
+  ResendVerificationOk,
+  ResendVerificationError,
+  ValidationErrorDetails
+>;
 
 // ---------------------------------------
 // POST /api/auth/verify-email
@@ -141,8 +143,7 @@ export type ChangePasswordRes = ApiResponse<
 // ---------------------------------------
 // GET /api/auth/callback/google
 // ---------------------------------------
-
-export type GoogleCallbackOk = null;
+// Success redirects with 302, JSON is only for error cases.
 
 export const AUTH_GOOGLE_CALLBACK_ERRORS = [
   'AUTH_CSRF_FAILED',
@@ -152,10 +153,10 @@ export const AUTH_GOOGLE_CALLBACK_ERRORS = [
 
 export type GoogleCallbackError = (typeof AUTH_GOOGLE_CALLBACK_ERRORS)[number];
 
-export type GoogleCallbackRes = ApiResponse<GoogleCallbackOk, GoogleCallbackError>;
+export type GoogleCallbackRes = ApiResponse<null, GoogleCallbackError>;
 
 // ---------------------------------------
-// GET /api/auth/me
+// GET /api/protected/me
 // ---------------------------------------
 
 export type AuthMeOk = {

--- a/containers/frontend/web/src/app/[locale]/(guest)/(auth)/layout.tsx
+++ b/containers/frontend/web/src/app/[locale]/(guest)/(auth)/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <main className="flex justify-center md:justify-end w-full md:pe-11 items-center">
+    <main className="flex justify-center md:min-h-[100dvh] md:justify-end w-full md:pe-11 items-center">
       <Stack
         className={glassCardStyles({
           className:

--- a/containers/frontend/web/src/app/api/auth/login/route.ts
+++ b/containers/frontend/web/src/app/api/auth/login/route.ts
@@ -1,11 +1,11 @@
-// app/api/auth/login/route.ts
 import { NextResponse } from 'next/server';
-import { proxyJsonWithSetCookie } from '@/lib/http/proxy.server';
+
+import { appendSetCookies, proxyJsonWithSetCookie } from '@/lib/http/proxy.server';
 
 export async function POST(req: Request) {
   const body = await req.json();
 
-  const { status, data, setCookie } = await proxyJsonWithSetCookie({
+  const { status, data, setCookies } = await proxyJsonWithSetCookie({
     endpoint: '/auth/login',
     method: 'POST',
     body,
@@ -13,9 +13,7 @@ export async function POST(req: Request) {
 
   const res = NextResponse.json(data, { status });
 
-  if (setCookie) {
-    res.headers.set('set-cookie', setCookie);
-  }
+  appendSetCookies(res.headers, setCookies);
 
   return res;
 }

--- a/containers/frontend/web/src/app/api/auth/verify-email/route.ts
+++ b/containers/frontend/web/src/app/api/auth/verify-email/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from 'next/server';
 
-import { proxyJsonWithSetCookie } from '@/lib/http/proxy.server';
+import { appendSetCookies, proxyJsonWithSetCookie } from '@/lib/http/proxy.server';
 
 export async function POST(req: Request) {
   const body = await req.json();
 
-  const { status, data, setCookie } = await proxyJsonWithSetCookie({
+  const { status, data, setCookies } = await proxyJsonWithSetCookie({
     endpoint: '/auth/verify-email',
     method: 'POST',
     body,
   });
 
   const res = NextResponse.json(data, { status });
-  if (setCookie) res.headers.set('set-cookie', setCookie);
+
+  appendSetCookies(res.headers, setCookies);
 
   return res;
 }

--- a/containers/frontend/web/src/features/auth/change-password/change-password.action.ts
+++ b/containers/frontend/web/src/features/auth/change-password/change-password.action.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from 'next/headers';
 import { fetchServer, withServerAction } from '@/lib/http/fetcher.server';
+import { ChangePasswordRes } from '@/contracts/api/auth/auth.contract';
 
 export async function changePasswordAction(_prevState: unknown, formData: FormData) {
   const currentPassword = String(formData.get('currentPassword') ?? '');
@@ -9,7 +10,7 @@ export async function changePasswordAction(_prevState: unknown, formData: FormDa
   const cookie = (await cookies()).toString();
 
   const result = await withServerAction(async () => {
-    const res = await fetchServer(
+    const res = await fetchServer<ChangePasswordRes>(
       '/protected/me/reset-password',
       'POST',
       {

--- a/containers/frontend/web/src/features/auth/change-password/change-password.action.ts
+++ b/containers/frontend/web/src/features/auth/change-password/change-password.action.ts
@@ -2,7 +2,7 @@
 
 import { cookies } from 'next/headers';
 import { fetchServer, withServerAction } from '@/lib/http/fetcher.server';
-import { ChangePasswordRes } from '@/contracts/api/auth/auth.contract';
+import type { ChangePasswordRes } from '@/contracts/api/auth/auth.contract';
 
 export async function changePasswordAction(_prevState: unknown, formData: FormData) {
   const currentPassword = String(formData.get('currentPassword') ?? '');

--- a/containers/frontend/web/src/features/auth/create-account/verify-email/verify-email.action.ts
+++ b/containers/frontend/web/src/features/auth/create-account/verify-email/verify-email.action.ts
@@ -6,35 +6,7 @@ import type { VerifyEmailRes } from '@/contracts/api/auth/auth.contract';
 import { fetchServer, withServerAction } from '@/lib/http/fetcher.server';
 import { VerifyEmailReqSchema } from '@/contracts/api/auth/auth.validation';
 import { getValidationErrorResult } from '@/lib/http/errors';
-
-const SESSION_MAX_AGE_S = 60 * 60 * 24 * 7;
-
-function getAuthCookie(headers: Headers): string[] {
-  if (typeof headers.getSetCookie === 'function') return headers.getSetCookie();
-
-  const setCookie = headers.get('set-cookie');
-  return setCookie ? [setCookie] : [];
-}
-
-async function setAuthCookies(headers: Headers) {
-  const setCookies = getAuthCookie(headers);
-  const cookieStore = await cookies();
-
-  for (const sc of setCookies) {
-    const [pair] = sc.split(';');
-    const eq = pair.indexOf('=');
-    const name = pair.slice(0, eq);
-    const value = pair.slice(eq + 1);
-
-    cookieStore.set(name, decodeURIComponent(value), {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: SESSION_MAX_AGE_S,
-    });
-  }
-}
+import { forwardAuthCookies } from '@/lib/http/auth-cookies.server';
 
 export const verifyEmailAction = withServerAction(
   async (token: string): Promise<VerifyEmailRes> => {
@@ -46,7 +18,7 @@ export const verifyEmailAction = withServerAction(
       token: parsedToken.data.token,
     });
 
-    if (data.ok) await setAuthCookies(headers);
+    if (data.ok) await forwardAuthCookies(headers);
 
     return data;
   },

--- a/containers/frontend/web/src/features/auth/create-account/verify-email/verify-email.action.ts
+++ b/containers/frontend/web/src/features/auth/create-account/verify-email/verify-email.action.ts
@@ -1,7 +1,5 @@
 'use server';
 
-import { cookies } from 'next/headers';
-
 import type { VerifyEmailRes } from '@/contracts/api/auth/auth.contract';
 import { fetchServer, withServerAction } from '@/lib/http/fetcher.server';
 import { VerifyEmailReqSchema } from '@/contracts/api/auth/auth.validation';

--- a/containers/frontend/web/src/features/auth/login/login.action.ts
+++ b/containers/frontend/web/src/features/auth/login/login.action.ts
@@ -1,40 +1,11 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { getLocale } from 'next-intl/server';
 import { redirect } from '@/i18n/navigation';
 import { fetchServer, withServerAction } from '@/lib/http/fetcher.server';
+import { forwardAuthCookies } from '@/lib/http/auth-cookies.server';
 
 import { type LoginRes } from '@/contracts/api/auth/auth.contract';
-
-const SESSION_MAX_AGE_S = 60 * 60 * 24 * 7;
-
-function getAuthCookie(headers: Headers): string[] {
-  if (typeof headers.getSetCookie === 'function') return headers.getSetCookie();
-
-  const setCookie = headers.get('set-cookie');
-  return setCookie ? [setCookie] : [];
-}
-
-async function setAuthCookies(headers: Headers) {
-  const setCookies = getAuthCookie(headers);
-  const cookieStore = await cookies();
-
-  for (const sc of setCookies) {
-    const [pair] = sc.split(';');
-    const eq = pair.indexOf('=');
-    const name = pair.slice(0, eq);
-    const value = pair.slice(eq + 1);
-
-    cookieStore.set(name, decodeURIComponent(value), {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: SESSION_MAX_AGE_S,
-    });
-  }
-}
 
 export async function loginAction(_prevState: unknown, formData: FormData) {
   const result = await withServerAction(async () => {
@@ -46,14 +17,12 @@ export async function loginAction(_prevState: unknown, formData: FormData) {
       password,
     });
 
-    if (!data.ok) return data;
-
-    await setAuthCookies(headers);
+    if (data.ok) await forwardAuthCookies(headers);
     return data;
   })();
 
   if (!result.ok) return result;
 
   const locale = await getLocale();
-  redirect({ href: '/me', locale });
+  redirect({ href: '/', locale });
 }

--- a/containers/frontend/web/src/lib/http/auth-cookies.server.ts
+++ b/containers/frontend/web/src/lib/http/auth-cookies.server.ts
@@ -5,8 +5,9 @@ import { cookies } from 'next/headers';
 const SESSION_MAX_AGE_S = 60 * 60 * 24 * 7;
 
 function getSetCookieHeaders(headers: Headers): string[] {
-  if (typeof headers.getSetCookie === 'function') {
-    return headers.getSetCookie();
+  const headersWithGetSetCookie = headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof headersWithGetSetCookie.getSetCookie === 'function') {
+    return headersWithGetSetCookie.getSetCookie();
   }
 
   const setCookie = headers.get('set-cookie');

--- a/containers/frontend/web/src/lib/http/auth-cookies.server.ts
+++ b/containers/frontend/web/src/lib/http/auth-cookies.server.ts
@@ -1,0 +1,37 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+const SESSION_MAX_AGE_S = 60 * 60 * 24 * 7;
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  if (typeof headers.getSetCookie === 'function') {
+    return headers.getSetCookie();
+  }
+
+  const setCookie = headers.get('set-cookie');
+  return setCookie ? [setCookie] : [];
+}
+
+export async function forwardAuthCookies(headers: Headers): Promise<void> {
+  const cookieStore = await cookies();
+  const setCookies = getSetCookieHeaders(headers);
+
+  for (const setCookie of setCookies) {
+    const [pair] = setCookie.split(';');
+    const eq = pair.indexOf('=');
+
+    if (eq === -1) continue;
+
+    const name = pair.slice(0, eq);
+    const value = pair.slice(eq + 1);
+
+    cookieStore.set(name, decodeURIComponent(value), {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: SESSION_MAX_AGE_S,
+    });
+  }
+}

--- a/containers/frontend/web/src/lib/http/fallback.ts
+++ b/containers/frontend/web/src/lib/http/fallback.ts
@@ -1,0 +1,8 @@
+export const FALLBACK = {
+  data: {
+    ok: false,
+    error: {
+      code: 'FETCH_FAILED',
+    },
+  },
+};

--- a/containers/frontend/web/src/lib/http/fetcher.client.ts
+++ b/containers/frontend/web/src/lib/http/fetcher.client.ts
@@ -1,6 +1,7 @@
 import { jsonBody } from './utils';
 import type { HttpMethod } from './utils';
 
+// TODO check when merged to main fallback
 export async function fetchClient<T>(
   endpoint: string,
   method: HttpMethod,

--- a/containers/frontend/web/src/lib/http/fetcher.server.ts
+++ b/containers/frontend/web/src/lib/http/fetcher.server.ts
@@ -1,21 +1,14 @@
 import { jsonBody } from './utils';
 import type { HttpMethod } from './utils';
 import { envServer } from '../config/env.server';
+import { FALLBACK } from './fallback';
+import { parseJsonSafe } from './parse-json-safe';
 
 const API_BASE_URL = envServer.apiBaseUrl;
 
 function cookieHeaders(cookie?: string): Record<string, string> {
   return cookie ? { Cookie: cookie } : {};
 }
-
-const FALLBACK = {
-  data: {
-    ok: false,
-    error: {
-      code: 'FETCH_FAILED',
-    },
-  },
-};
 
 export function withServerAction<TArgs extends unknown[], TResult>(
   handler: (...args: TArgs) => Promise<TResult>,
@@ -52,7 +45,7 @@ export async function fetchServer<T>(
     cache: 'no-store',
   });
   const text = await res.text();
-  const json = text ? JSON.parse(text) : null;
+  const json = await parseJsonSafe<T>(text);
   if (!res.ok) {
     return { data: json as T, headers: res.headers, status: res.status };
   }

--- a/containers/frontend/web/src/lib/http/parse-json-safe.ts
+++ b/containers/frontend/web/src/lib/http/parse-json-safe.ts
@@ -1,7 +1,7 @@
 import { FALLBACK } from './fallback';
 
 export function parseJsonSafe<T>(text: string): T | null {
-  if (!text) return null;
+  if (!text) return FALLBACK.data as T;
 
   try {
     return JSON.parse(text) as T;

--- a/containers/frontend/web/src/lib/http/parse-json-safe.ts
+++ b/containers/frontend/web/src/lib/http/parse-json-safe.ts
@@ -1,6 +1,6 @@
 import { FALLBACK } from './fallback';
 
-export async function parseJsonSafe<T>(text: string): Promise<T | null> {
+export function parseJsonSafe<T>(text: string): T | null {
   if (!text) return null;
 
   try {

--- a/containers/frontend/web/src/lib/http/parse-json-safe.ts
+++ b/containers/frontend/web/src/lib/http/parse-json-safe.ts
@@ -1,0 +1,11 @@
+import { FALLBACK } from './fallback';
+
+export async function parseJsonSafe<T>(text: string): Promise<T | null> {
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return FALLBACK.data as T;
+  }
+}

--- a/containers/frontend/web/src/lib/http/proxy.server.ts
+++ b/containers/frontend/web/src/lib/http/proxy.server.ts
@@ -1,5 +1,6 @@
 import type { HttpMethod } from './utils';
 import { envServer } from '../config/env.server';
+import { parseJsonSafe } from './parse-json-safe';
 
 const API_BASE_URL = envServer.apiBaseUrl;
 
@@ -7,7 +8,7 @@ export async function proxyJsonWithSetCookie(args: {
   endpoint: string;
   method: HttpMethod;
   body: unknown;
-}): Promise<{ status: number; data: unknown; setCookie: string | null }> {
+}): Promise<{ status: number; data: unknown; setCookie: string | string[] | null }> {
   const res = await fetch(`${API_BASE_URL}${args.endpoint}`, {
     method: args.method,
     headers: {
@@ -18,8 +19,9 @@ export async function proxyJsonWithSetCookie(args: {
     cache: 'no-store',
   });
 
-  const data = await res.json();
-  const setCookie = res.headers.get('set-cookie');
+  const data = await parseJsonSafe(res);
+
+  const setCookie = (res.headers as any).getSetCookie?.() ?? res.headers.get('set-cookie');
 
   return { status: res.status, data, setCookie };
 }

--- a/containers/frontend/web/src/lib/http/proxy.server.ts
+++ b/containers/frontend/web/src/lib/http/proxy.server.ts
@@ -24,7 +24,7 @@ export async function proxyJsonWithSetCookie(args: {
   });
 
   const text = await res.text();
-  const data = await parseJsonSafe(text);
+  const data = parseJsonSafe(text);
 
   const headers = res.headers as HeadersWithSetCookie;
   const setCookie = headers.getSetCookie?.() ?? headers.get('set-cookie');

--- a/containers/frontend/web/src/lib/http/proxy.server.ts
+++ b/containers/frontend/web/src/lib/http/proxy.server.ts
@@ -4,6 +4,10 @@ import { parseJsonSafe } from './parse-json-safe';
 
 const API_BASE_URL = envServer.apiBaseUrl;
 
+type HeadersWithSetCookie = Headers & {
+  getSetCookie?: () => string[];
+};
+
 export async function proxyJsonWithSetCookie(args: {
   endpoint: string;
   method: HttpMethod;
@@ -19,9 +23,11 @@ export async function proxyJsonWithSetCookie(args: {
     cache: 'no-store',
   });
 
-  const data = await parseJsonSafe(res);
+  const text = await res.text();
+  const data = await parseJsonSafe(text);
 
-  const setCookie = (res.headers as any).getSetCookie?.() ?? res.headers.get('set-cookie');
+  const headers = res.headers as HeadersWithSetCookie;
+  const setCookie = headers.getSetCookie?.() ?? headers.get('set-cookie');
 
   return { status: res.status, data, setCookie };
 }

--- a/containers/frontend/web/src/lib/http/proxy.server.ts
+++ b/containers/frontend/web/src/lib/http/proxy.server.ts
@@ -8,11 +8,31 @@ type HeadersWithSetCookie = Headers & {
   getSetCookie?: () => string[];
 };
 
+function getSetCookies(headers: Headers): string[] {
+  const headersWithSetCookie = headers as HeadersWithSetCookie;
+
+  const setCookies = headersWithSetCookie.getSetCookie?.();
+
+  if (setCookies?.length) {
+    return setCookies;
+  }
+
+  const setCookie = headers.get('set-cookie');
+
+  return setCookie ? [setCookie] : [];
+}
+
+export function appendSetCookies(headers: Headers, setCookies: string[]) {
+  for (const setCookie of setCookies) {
+    headers.append('set-cookie', setCookie);
+  }
+}
+
 export async function proxyJsonWithSetCookie(args: {
   endpoint: string;
   method: HttpMethod;
   body: unknown;
-}): Promise<{ status: number; data: unknown; setCookie: string | string[] | null }> {
+}): Promise<{ status: number; data: unknown; setCookies: string[] }> {
   const res = await fetch(`${API_BASE_URL}${args.endpoint}`, {
     method: args.method,
     headers: {
@@ -26,8 +46,9 @@ export async function proxyJsonWithSetCookie(args: {
   const text = await res.text();
   const data = parseJsonSafe(text);
 
-  const headers = res.headers as HeadersWithSetCookie;
-  const setCookie = headers.getSetCookie?.() ?? headers.get('set-cookie');
-
-  return { status: res.status, data, setCookie };
+  return {
+    status: res.status,
+    data,
+    setCookies: getSetCookies(res.headers),
+  };
 }

--- a/containers/frontend/web/tsconfig.json
+++ b/containers/frontend/web/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "baseUrl": "./",
     "paths": {
       "@components": ["src/components/index.ts"],


### PR DESCRIPTION
# Auth – Changes

## P0 (Blocking)

| Area | Change |
|------|--------|
| `auth.contract.ts` | Replace plain `ApiResponse` with typed generics for all responses (`SignupRes`, `LoginRes`, `LogoutRes`, `ResendVerificationRes`, `VerifyEmailRes`, `GoogleCallbackRes`, `MeRes`, `RecoverRes`) |
| `auth.contract.ts` | Update route comment from `GET /api/auth/me` → `GET /api/protected/me` |
| `fetcher.server.ts` | Add safe JSON parsing (`JSON.parse` can crash on HTML/non-JSON responses) |
| `proxy.server.ts` | Replace `await res.json()` with safe parsing |

---

## P1 (High Priority)

| Area | Change |
|------|--------|
| `fetcher.client.ts` | Extract shared safe JSON parser instead of relying on outer `try/catch` |
| `auth.contract.ts` | Remove masked errors from resend verification: `AUTH_RESEND_VERIFICATION_NOT_FOUND`, `AUTH_RESEND_VERIFICATION_COOLDOWN` |
| `auth.contract.ts` | Document Google callback success as `302 redirect` instead of JSON response |
| FE auth actions | Strongly type all calls (`fetchServer<LoginRes>()`, `fetchServer<SignupRes>()`, etc.) |
| FE auth actions | Centralize cookie forwarding logic into a shared helper |

---

## P2 (Nice to Have / Consistency)

| Area | Change |
|------|--------|
| Error handling | Standardize `FETCH_FAILED` as a shared error code across FE/API |
