### PR TITLE
feat(i18n): update translations for ai automation

### DIFF
--- a/containers/frontend/web/.eslint/only-i18n-strings.config.mjs
+++ b/containers/frontend/web/.eslint/only-i18n-strings.config.mjs
@@ -1,0 +1,36 @@
+import tsParser from '@typescript-eslint/parser';
+import globals from 'globals';
+import ignores from '../eslint.ignore.mjs';
+import noLiteralUiStrings from './only-i18n-strings.mjs';
+
+export default [
+  ignores,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/app/\\[locale\\]/(public)/ui/**', 'src/features/game/*'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: new URL('..', import.meta.url).pathname,
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      local: {
+        rules: {
+          'no-literal-ui-strings': noLiteralUiStrings,
+        },
+      },
+    },
+    rules: {
+      'local/no-literal-ui-strings': 'error',
+    },
+  },
+];

--- a/containers/frontend/web/scripts/i18n/apply-locale-patches.mjs
+++ b/containers/frontend/web/scripts/i18n/apply-locale-patches.mjs
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import util from 'node:util';
+
+const targets = [
+  {
+    patchPath: '.tmp/i18n-locale-patch.ca.json',
+    localePath: './src/i18n/messages/ca.json',
+    language: 'ca',
+  },
+  {
+    patchPath: '.tmp/i18n-locale-patch.en.json',
+    localePath: './src/i18n/messages/en.json',
+    language: 'en',
+  },
+  {
+    patchPath: '.tmp/i18n-locale-patch.es.json',
+    localePath: './src/i18n/messages/es.json',
+    language: 'es',
+  },
+];
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, value) {
+  fs.writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeDeep(target, source, collisions, prefix = '') {
+  for (const key of Object.keys(source)) {
+    const sourceValue = source[key];
+    const targetValue = target[key];
+    const nextPath = prefix ? `${prefix}.${key}` : key;
+
+    if (isPlainObject(sourceValue) && isPlainObject(targetValue)) {
+      mergeDeep(targetValue, sourceValue, collisions, nextPath);
+      continue;
+    }
+
+    if (!(key in target)) {
+      target[key] = sourceValue;
+      continue;
+    }
+
+    if (JSON.stringify(targetValue) === JSON.stringify(sourceValue)) {
+      continue;
+    }
+
+    collisions.push({
+      path: nextPath,
+      existing: targetValue,
+      incoming: sourceValue,
+    });
+  }
+}
+
+const summary = [];
+
+for (const target of targets) {
+  if (!fs.existsSync(target.patchPath)) {
+    summary.push({
+      language: target.language,
+      status: 'skipped',
+      reason: `Patch not found: ${target.patchPath}`,
+    });
+    continue;
+  }
+
+  if (!fs.existsSync(target.localePath)) {
+    summary.push({
+      language: target.language,
+      status: 'skipped',
+      reason: `Locale file not found: ${target.localePath}`,
+    });
+    continue;
+  }
+
+  const patch = readJson(target.patchPath);
+  const locale = readJson(target.localePath);
+  const collisions = [];
+
+  mergeDeep(locale, patch, collisions);
+
+  writeJson(target.localePath, locale);
+
+  summary.push({
+    language: target.language,
+    status: 'updated',
+    localePath: target.localePath,
+    patchPath: target.patchPath,
+    collisions,
+  });
+}
+
+console.log(
+  util.inspect(summary, {
+    depth: null,
+    colors: true,
+    maxArrayLength: null,
+  }),
+);
+
+const updated = summary.filter((item) => item.status === 'updated').length;
+const skipped = summary.filter((item) => item.status === 'skipped').length;
+const collisions = summary.reduce((total, item) => total + (item.collisions?.length ?? 0), 0);
+
+console.log(`\nLocales updated: ${updated}`);
+console.log(`Locales skipped: ${skipped}`);
+console.log(`Collisions found: ${collisions}`);

--- a/containers/frontend/web/scripts/i18n/build-ai-payload.mjs
+++ b/containers/frontend/web/scripts/i18n/build-ai-payload.mjs
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import util from 'node:util';
+
+const violations = JSON.parse(fs.readFileSync('.tmp/i18n-literals.json', 'utf8'));
+const locales = {
+  ca: JSON.parse(fs.readFileSync('./src/i18n/messages/ca.json', 'utf8')),
+  en: JSON.parse(fs.readFileSync('./src/i18n/messages/en.json', 'utf8')),
+  es: JSON.parse(fs.readFileSync('./src/i18n/messages/es.json', 'utf8')),
+};
+
+const i18nRules = {
+  decisionRule: {
+    globalOrReused: 'common',
+    reusableUi: 'components',
+    layoutRelated: 'layouts',
+    routeSpecific: 'pages',
+    businessOrDomain: 'features',
+    validation: 'validation',
+    backendErrors: 'errors',
+  },
+  naming: {
+    namespaces: 'lowercase',
+    keys: 'camelCase',
+  },
+  featuresRule: 'features.<feature>.<section>.<key>',
+  specialRules: [
+    'validation and errors must stay top-level',
+    'backend error codes must match backend codes',
+    'shared UI copy that is not a backend error code should live under common',
+    'if a translation binding already exists in scope, prefer reusing that namespace',
+    'if multiple bindings exist, choose the nearest relevant one',
+    'a single file may contain violations from different namespaces',
+    'namespace must be returned per violation, not per file',
+    'return translations for ca, en, and es',
+    'reuse existing keys from locale files when possible',
+    'return only structured JSON',
+  ],
+  localeTreeShape: {
+    common: {},
+    components: {},
+    layouts: {},
+    pages: {},
+    features: {},
+    validation: {},
+    errors: {},
+  },
+};
+
+function compactViolation(violation) {
+  return {
+    line: violation.line,
+    column: violation.column,
+    location: violation.location,
+    text: violation.text,
+    nodeType: violation.nodeType,
+    matchedNodeType: violation.matchedNodeType,
+    functionName: violation.functionName,
+    scopeBindings: violation.scopeBindings,
+  };
+}
+
+function compactFile(file) {
+  return {
+    filePath: file.filePath,
+    componentType: file.componentType,
+    imports: file.imports,
+    violations: file.violations.map((violation) => compactViolation(violation)),
+  };
+}
+
+const aiPayload = {
+  instructions: {
+    goal: 'Generate precise i18n proposals for the reported violations.',
+    constraints: [
+      'Resolve namespace per violation, not per file.',
+      'Reuse existing translation namespace bindings when appropriate.',
+      'If no binding exists, propose the best namespace according to the project rules.',
+      'Prefer local keys in replacements when a namespace binding is used.',
+      'If equivalent meaning already exists in locale files, reuse that key instead of creating a new one.',
+      'For template strings with variables or counts, prefer interpolation.',
+      'Mark ambiguous cases with needsReview: true.',
+      'Do not return prose. Return only valid JSON.',
+    ],
+    expectedResponseShape: {
+      files: [
+        {
+          filePath: 'string',
+          violations: [
+            {
+              line: 'number',
+              column: 'number',
+              functionName: 'string|null',
+              namespace: 'string|null',
+              translator: {
+                kind: 'useTranslations|getTranslations|null',
+                variable: 'string|null',
+                needsImport: 'boolean',
+                needsBinding: 'boolean',
+                suggestedBinding: 'string|null',
+              },
+              text: 'string|null',
+              kind: 'plain-text|template-with-variable|template-with-count|partially-translated-template|unknown',
+              key: 'string|null',
+              fullKey: 'string|null',
+              localeValues: {
+                ca: 'string|null',
+                en: 'string|null',
+                es: 'string|null',
+              },
+              replacement: 'string|null',
+              reusedExistingKey: 'boolean',
+              needsReview: 'boolean',
+              confidence: 'high|medium|low',
+              rationale: 'string',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  projectI18nRules: i18nRules,
+  existingLocales: locales,
+  files: violations.map((file) => compactFile(file)),
+};
+
+fs.mkdirSync('.tmp', { recursive: true });
+fs.writeFileSync('.tmp/i18n-ai-payload.json', JSON.stringify(aiPayload, null, 2));
+
+console.log(
+  util.inspect(aiPayload, {
+    depth: null,
+    colors: true,
+    maxArrayLength: null,
+  }),
+);
+
+console.log('\nSaved .tmp/i18n-ai-payload.json');
+console.log(`Files in payload: ${aiPayload.files.length}`);
+
+const totalViolations = aiPayload.files.reduce((total, file) => total + file.violations.length, 0);
+
+console.log(`Violations in payload: ${totalViolations}`);

--- a/containers/frontend/web/scripts/i18n/build-output-files.mjs
+++ b/containers/frontend/web/scripts/i18n/build-output-files.mjs
@@ -1,0 +1,342 @@
+import fs from 'node:fs';
+import util from 'node:util';
+
+const aiResponse = JSON.parse(fs.readFileSync('.tmp/i18n-ai-response.json', 'utf8'));
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function toNestedObject(path, value) {
+  const parts = path.split('.');
+  const root = {};
+  let current = root;
+
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    current[parts[i]] = {};
+    current = current[parts[i]];
+  }
+
+  current[parts.at(-1)] = value;
+  return root;
+}
+
+function mergeDeep(target, source) {
+  for (const key of Object.keys(source)) {
+    const sourceValue = source[key];
+    const targetValue = target[key];
+
+    if (
+      sourceValue &&
+      typeof sourceValue === 'object' &&
+      !Array.isArray(sourceValue) &&
+      targetValue &&
+      typeof targetValue === 'object' &&
+      !Array.isArray(targetValue)
+    ) {
+      mergeDeep(targetValue, sourceValue);
+    } else if (!(key in target)) {
+      target[key] = sourceValue;
+    }
+  }
+}
+
+function normalizeViolation(violation) {
+  const normalized = { ...violation };
+
+  if (normalized.namespace === undefined) normalized.namespace = null;
+  if (normalized.fullKey === undefined) normalized.fullKey = null;
+  if (normalized.text === undefined) normalized.text = null;
+  if (normalized.functionName === undefined) normalized.functionName = null;
+  if (normalized.replacement === undefined) normalized.replacement = null;
+  if (normalized.key === undefined) normalized.key = null;
+
+  if (normalized.localeValues === undefined || normalized.localeValues === null) {
+    normalized.localeValues = {
+      ca: null,
+      en: null,
+      es: null,
+    };
+  } else {
+    normalized.localeValues = {
+      ca: normalized.localeValues.ca ?? null,
+      en: normalized.localeValues.en ?? null,
+      es: normalized.localeValues.es ?? null,
+    };
+  }
+
+  if (normalized.translator === undefined || normalized.translator === null) {
+    normalized.translator = {
+      kind: null,
+      variable: null,
+      needsImport: false,
+      needsBinding: false,
+      suggestedBinding: null,
+    };
+  } else {
+    normalized.translator = {
+      kind: normalized.translator.kind ?? null,
+      variable: normalized.translator.variable ?? null,
+      needsImport: normalized.translator.needsImport ?? false,
+      needsBinding: normalized.translator.needsBinding ?? false,
+      suggestedBinding: normalized.translator.suggestedBinding ?? null,
+    };
+  }
+
+  if (normalized.reusedExistingKey === undefined) {
+    normalized.reusedExistingKey = false;
+  }
+
+  if (normalized.namespace === null && typeof normalized.fullKey === 'string') {
+    const parts = normalized.fullKey.split('.');
+    if (parts.length > 1) {
+      normalized.namespace = parts.slice(0, -1).join('.');
+    }
+  }
+
+  if (
+    normalized.fullKey === null &&
+    typeof normalized.namespace === 'string' &&
+    typeof normalized.key === 'string'
+  ) {
+    normalized.fullKey = `${normalized.namespace}.${normalized.key}`;
+  }
+
+  return normalized;
+}
+
+function normalizeResponse(data) {
+  return {
+    ...data,
+    files: (data.files ?? []).map((file) => ({
+      ...file,
+      violations: (file.violations ?? []).map((violation) => normalizeViolation(violation)),
+    })),
+  };
+}
+
+function validateTranslator(translator, location) {
+  assert(translator && typeof translator === 'object', `Invalid translator at ${location}`);
+
+  assert(
+    translator.kind === null ||
+      translator.kind === 'useTranslations' ||
+      translator.kind === 'getTranslations',
+    `Invalid translator.kind at ${location}`,
+  );
+
+  assert(
+    translator.variable === null || typeof translator.variable === 'string',
+    `Invalid translator.variable at ${location}`,
+  );
+
+  assert(
+    typeof translator.needsImport === 'boolean',
+    `Invalid translator.needsImport at ${location}`,
+  );
+
+  assert(
+    typeof translator.needsBinding === 'boolean',
+    `Invalid translator.needsBinding at ${location}`,
+  );
+
+  assert(
+    translator.suggestedBinding === null || typeof translator.suggestedBinding === 'string',
+    `Invalid translator.suggestedBinding at ${location}`,
+  );
+}
+
+function validateLocaleValues(localeValues, location) {
+  assert(localeValues && typeof localeValues === 'object', `Missing localeValues at ${location}`);
+
+  for (const lang of ['ca', 'en', 'es']) {
+    assert(
+      localeValues[lang] === null || typeof localeValues[lang] === 'string',
+      `Invalid localeValues.${lang} at ${location}`,
+    );
+  }
+}
+
+function validateViolation(violation, filePath) {
+  const location = `${filePath}:${violation.line}:${violation.column}`;
+
+  assert(typeof violation.line === 'number', `Invalid line at ${filePath}`);
+  assert(typeof violation.column === 'number', `Invalid column at ${filePath}`);
+  assert(
+    violation.functionName === null || typeof violation.functionName === 'string',
+    `Invalid functionName at ${location}`,
+  );
+
+  assert(
+    violation.namespace === null || typeof violation.namespace === 'string',
+    `Invalid namespace at ${location}`,
+  );
+
+  validateTranslator(violation.translator, location);
+
+  assert(
+    violation.text === null || typeof violation.text === 'string',
+    `Invalid text at ${location}`,
+  );
+
+  assert(
+    violation.kind === 'plain-text' ||
+      violation.kind === 'template-with-variable' ||
+      violation.kind === 'template-with-count' ||
+      violation.kind === 'partially-translated-template' ||
+      violation.kind === 'unknown',
+    `Invalid kind at ${location}`,
+  );
+
+  assert(violation.key === null || typeof violation.key === 'string', `Invalid key at ${location}`);
+
+  assert(
+    violation.fullKey === null || typeof violation.fullKey === 'string',
+    `Invalid fullKey at ${location}`,
+  );
+
+  validateLocaleValues(violation.localeValues, location);
+
+  assert(
+    violation.replacement === null || typeof violation.replacement === 'string',
+    `Invalid replacement at ${location}`,
+  );
+
+  assert(
+    typeof violation.reusedExistingKey === 'boolean',
+    `Invalid reusedExistingKey at ${location}`,
+  );
+
+  assert(typeof violation.needsReview === 'boolean', `Invalid needsReview at ${location}`);
+
+  assert(
+    violation.confidence === 'high' ||
+      violation.confidence === 'medium' ||
+      violation.confidence === 'low',
+    `Invalid confidence at ${location}`,
+  );
+
+  assert(typeof violation.rationale === 'string', `Invalid rationale at ${location}`);
+}
+
+function validateResponse(data) {
+  assert(data && typeof data === 'object', 'AI response must be an object');
+  assert(Array.isArray(data.files), 'AI response must contain files[]');
+
+  for (const file of data.files) {
+    assert(typeof file.filePath === 'string', 'Each file must have filePath');
+    assert(Array.isArray(file.violations), `Violations must be an array for ${file.filePath}`);
+
+    for (const violation of file.violations) {
+      validateViolation(violation, file.filePath);
+    }
+  }
+}
+
+function buildProposals(data) {
+  return data.files.map((file) => ({
+    filePath: file.filePath,
+    proposals: file.violations.map((violation) => ({
+      line: violation.line,
+      column: violation.column,
+      functionName: violation.functionName,
+      namespace: violation.namespace,
+      translator: violation.translator,
+      text: violation.text,
+      kind: violation.kind,
+      key: violation.key,
+      fullKey: violation.fullKey,
+      localeValues: violation.localeValues,
+      replacement: violation.replacement,
+      reusedExistingKey: violation.reusedExistingKey,
+      needsReview: violation.needsReview,
+      confidence: violation.confidence,
+      rationale: violation.rationale,
+    })),
+  }));
+}
+
+function buildLocalePatchForLanguage(data, language) {
+  const localePatch = {};
+
+  for (const file of data.files) {
+    for (const violation of file.violations) {
+      if (!violation.fullKey || !violation.localeValues?.[language]) continue;
+
+      const nestedPatch = toNestedObject(violation.fullKey, violation.localeValues[language]);
+      mergeDeep(localePatch, nestedPatch);
+    }
+  }
+
+  return localePatch;
+}
+
+function buildCodePatch(data) {
+  return data.files.map((file) => ({
+    filePath: file.filePath,
+    edits: file.violations
+      .filter((violation) => violation.replacement)
+      .map((violation) => ({
+        line: violation.line,
+        column: violation.column,
+        functionName: violation.functionName,
+        namespace: violation.namespace,
+        translator: violation.translator,
+        key: violation.key,
+        fullKey: violation.fullKey,
+        replacement: violation.replacement,
+        needsReview: violation.needsReview,
+        confidence: violation.confidence,
+      })),
+  }));
+}
+
+const normalizedResponse = normalizeResponse(aiResponse);
+
+validateResponse(normalizedResponse);
+
+const proposals = buildProposals(normalizedResponse);
+const localePatchCa = buildLocalePatchForLanguage(normalizedResponse, 'ca');
+const localePatchEn = buildLocalePatchForLanguage(normalizedResponse, 'en');
+const localePatchEs = buildLocalePatchForLanguage(normalizedResponse, 'es');
+const codePatch = buildCodePatch(normalizedResponse);
+
+fs.mkdirSync('.tmp', { recursive: true });
+fs.writeFileSync('.tmp/i18n-proposals.json', JSON.stringify(proposals, null, 2));
+fs.writeFileSync('.tmp/i18n-locale-patch.ca.json', JSON.stringify(localePatchCa, null, 2));
+fs.writeFileSync('.tmp/i18n-locale-patch.en.json', JSON.stringify(localePatchEn, null, 2));
+fs.writeFileSync('.tmp/i18n-locale-patch.es.json', JSON.stringify(localePatchEs, null, 2));
+fs.writeFileSync('.tmp/i18n-code-patch.json', JSON.stringify(codePatch, null, 2));
+
+console.log(
+  util.inspect(
+    {
+      proposals,
+      localePatchCa,
+      localePatchEn,
+      localePatchEs,
+      codePatch,
+    },
+    {
+      depth: null,
+      colors: true,
+      maxArrayLength: null,
+    },
+  ),
+);
+
+const filesWithErrors = proposals.length;
+const totalProposals = proposals.reduce((total, file) => total + file.proposals.length, 0);
+const needsReview = proposals.reduce(
+  (total, file) => total + file.proposals.filter((proposal) => proposal.needsReview).length,
+  0,
+);
+
+console.log(`\nFiles with errors: ${filesWithErrors}`);
+console.log(`Proposals generated: ${totalProposals}`);
+console.log(`Needs review: ${needsReview}`);
+console.log('Saved .tmp/i18n-proposals.json');
+console.log('Saved .tmp/i18n-locale-patch.ca.json');
+console.log('Saved .tmp/i18n-locale-patch.en.json');
+console.log('Saved .tmp/i18n-locale-patch.es.json');
+console.log('Saved .tmp/i18n-code-patch.json');

--- a/containers/frontend/web/scripts/i18n/extract-eslint-violations.mjs
+++ b/containers/frontend/web/scripts/i18n/extract-eslint-violations.mjs
@@ -1,0 +1,278 @@
+import fs from 'node:fs';
+import { parse } from '@typescript-eslint/typescript-estree';
+import util from 'node:util';
+
+const input = JSON.parse(fs.readFileSync('.tmp/i18n-violations.json', 'utf8'));
+
+function visit(node, cb) {
+  if (!node || typeof node !== 'object') return;
+  cb(node);
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, cb);
+    } else if (value && typeof value === 'object' && value.type) {
+      visit(value, cb);
+    }
+  }
+}
+
+function matchesViolation(node, violation) {
+  if (!node.loc) return false;
+  return node.loc.start.line === violation.line && node.loc.start.column + 1 === violation.column;
+}
+
+function extractText(node, source) {
+  if (node.type === 'JSXText') return node.value.trim();
+
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
+  }
+
+  if (node.type === 'TemplateLiteral') {
+    return source.slice(node.range[0], node.range[1]);
+  }
+
+  return source.slice(node.range[0], node.range[1]);
+}
+
+function buildLocation(filePath, line, column) {
+  return `${filePath}:${line}:${column}`;
+}
+
+function getComponentType(ast) {
+  const firstStatement = ast.body?.[0];
+
+  if (
+    firstStatement?.type === 'ExpressionStatement' &&
+    firstStatement.expression?.type === 'Literal' &&
+    firstStatement.expression.value === 'use client'
+  ) {
+    return 'client';
+  }
+
+  return 'server';
+}
+
+function getTranslationImports(ast) {
+  let hasUseTranslations = false;
+  let hasGetTranslations = false;
+
+  for (const node of ast.body ?? []) {
+    if (node.type !== 'ImportDeclaration') continue;
+
+    for (const specifier of node.specifiers ?? []) {
+      if (specifier.type !== 'ImportSpecifier') continue;
+
+      const importedName =
+        specifier.imported.type === 'Identifier'
+          ? specifier.imported.name
+          : specifier.imported.value;
+
+      if (importedName === 'useTranslations') hasUseTranslations = true;
+      if (importedName === 'getTranslations') hasGetTranslations = true;
+    }
+  }
+
+  return {
+    useTranslations: hasUseTranslations,
+    getTranslations: hasGetTranslations,
+  };
+}
+
+function isFunctionNode(node) {
+  return (
+    node?.type === 'FunctionDeclaration' ||
+    node?.type === 'FunctionExpression' ||
+    node?.type === 'ArrowFunctionExpression'
+  );
+}
+
+function containsLocation(node, violation) {
+  if (!node.loc) return false;
+
+  const line = violation.line;
+  const column = violation.column - 1;
+
+  const startsBefore =
+    node.loc.start.line < line || (node.loc.start.line === line && node.loc.start.column <= column);
+
+  const endsAfter =
+    node.loc.end.line > line || (node.loc.end.line === line && node.loc.end.column >= column);
+
+  return startsBefore && endsAfter;
+}
+
+function findEnclosingFunction(ast, violation) {
+  let best = null;
+
+  visit(ast, (node) => {
+    if (!isFunctionNode(node)) return;
+    if (!containsLocation(node, violation)) return;
+
+    if (!best) {
+      best = node;
+      return;
+    }
+
+    const bestSpan =
+      (best.loc.end.line - best.loc.start.line) * 10000 +
+      (best.loc.end.column - best.loc.start.column);
+
+    const nodeSpan =
+      (node.loc.end.line - node.loc.start.line) * 10000 +
+      (node.loc.end.column - node.loc.start.column);
+
+    if (nodeSpan < bestSpan) best = node;
+  });
+
+  return best;
+}
+
+function getFunctionName(fnNode, ast) {
+  if (!fnNode) return null;
+
+  if (fnNode.type === 'FunctionDeclaration' && fnNode.id?.name) {
+    return fnNode.id.name;
+  }
+
+  let foundName = null;
+
+  visit(ast, (node) => {
+    if (foundName) return;
+
+    if (
+      node.type === 'VariableDeclarator' &&
+      node.id?.type === 'Identifier' &&
+      node.init === fnNode
+    ) {
+      foundName = node.id.name;
+      return;
+    }
+
+    if (
+      node.type === 'Property' &&
+      node.value === fnNode &&
+      !node.computed &&
+      node.key?.type === 'Identifier'
+    ) {
+      foundName = node.key.name;
+    }
+  });
+
+  return foundName;
+}
+
+function getTranslationBindingsInNode(rootNode) {
+  const bindings = [];
+
+  visit(rootNode, (node) => {
+    if (node !== rootNode && isFunctionNode(node)) return;
+
+    if (node.type !== 'VariableDeclarator') return;
+    if (!node.init) return;
+    if (node.id.type !== 'Identifier') return;
+
+    let callNode = null;
+    let kind = null;
+
+    if (node.init.type === 'CallExpression' && node.init.callee?.type === 'Identifier') {
+      if (node.init.callee.name === 'useTranslations') {
+        callNode = node.init;
+        kind = 'useTranslations';
+      } else if (node.init.callee.name === 'getTranslations') {
+        callNode = node.init;
+        kind = 'getTranslations';
+      }
+    }
+
+    if (
+      node.init.type === 'AwaitExpression' &&
+      node.init.argument?.type === 'CallExpression' &&
+      node.init.argument.callee?.type === 'Identifier' &&
+      node.init.argument.callee.name === 'getTranslations'
+    ) {
+      callNode = node.init.argument;
+      kind = 'getTranslations';
+    }
+
+    if (!callNode || !kind) return;
+
+    const firstArg = callNode.arguments?.[0];
+    let namespace = null;
+
+    if (firstArg?.type === 'Literal' && typeof firstArg.value === 'string') {
+      namespace = firstArg.value;
+    }
+
+    if (
+      firstArg?.type === 'TemplateLiteral' &&
+      firstArg.expressions.length === 0 &&
+      firstArg.quasis.length === 1
+    ) {
+      namespace = firstArg.quasis[0].value.cooked ?? null;
+    }
+
+    bindings.push({
+      kind,
+      variable: node.id.name,
+      namespace,
+    });
+  });
+
+  return bindings;
+}
+
+const enriched = input.map((file) => {
+  const ast = parse(file.source, {
+    loc: true,
+    range: true,
+    jsx: true,
+  });
+
+  const componentType = getComponentType(ast);
+  const imports = getTranslationImports(ast);
+
+  const nextViolations = file.violations.map((violation) => {
+    let found = null;
+
+    visit(ast, (node) => {
+      if (found) return;
+      if (matchesViolation(node, violation)) found = node;
+    });
+
+    const enclosingFunction = findEnclosingFunction(ast, violation);
+    const functionName = getFunctionName(enclosingFunction, ast);
+    const scopeBindings = enclosingFunction ? getTranslationBindingsInNode(enclosingFunction) : [];
+
+    return {
+      ...violation,
+      text: found ? extractText(found, file.source) : null,
+      matchedNodeType: found?.type ?? null,
+      location: buildLocation(file.filePath, violation.line, violation.column),
+      functionName,
+      scopeBindings,
+    };
+  });
+
+  return {
+    filePath: file.filePath,
+    componentType,
+    imports,
+    violations: nextViolations,
+  };
+});
+
+fs.writeFileSync('.tmp/i18n-literals.json', JSON.stringify(enriched, null, 2));
+
+console.log(
+  util.inspect(enriched, {
+    depth: null,
+    colors: true,
+    maxArrayLength: null,
+  }),
+);
+
+const filesWithErrors = enriched.length;
+
+console.log(`\nFiles with errors: ${filesWithErrors}`);

--- a/containers/frontend/web/scripts/i18n/sort-locales.mjs
+++ b/containers/frontend/web/scripts/i18n/sort-locales.mjs
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+
+const ROOT_ORDER = ['common', 'components', 'layouts', 'pages', 'features', 'validation', 'errors'];
+
+const LOCALE_FILES = [
+  './src/i18n/messages/ca.json',
+  './src/i18n/messages/en.json',
+  './src/i18n/messages/es.json',
+];
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sortObjectRecursively(value) {
+  if (!isPlainObject(value)) return value;
+
+  const sortedKeys = Object.keys(value).sort((a, b) => a.localeCompare(b));
+  const result = {};
+
+  for (const key of sortedKeys) {
+    result[key] = sortObjectRecursively(value[key]);
+  }
+
+  return result;
+}
+
+function sortLocaleRoot(locale) {
+  const result = {};
+
+  for (const key of ROOT_ORDER) {
+    if (key in locale) {
+      result[key] = sortObjectRecursively(locale[key]);
+    }
+  }
+
+  const extraKeys = Object.keys(locale)
+    .filter((key) => !ROOT_ORDER.includes(key))
+    .sort((a, b) => a.localeCompare(b));
+
+  for (const key of extraKeys) {
+    result[key] = sortObjectRecursively(locale[key]);
+  }
+
+  return result;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+const summary = [];
+
+for (const filePath of LOCALE_FILES) {
+  if (!fs.existsSync(filePath)) {
+    summary.push({
+      filePath,
+      status: 'skipped',
+      reason: 'File not found',
+    });
+    continue;
+  }
+
+  const original = readJson(filePath);
+  const sorted = sortLocaleRoot(original);
+  const changed = JSON.stringify(original) !== JSON.stringify(sorted);
+
+  writeJson(filePath, sorted);
+
+  summary.push({
+    filePath,
+    status: 'sorted',
+    changed,
+  });
+}
+
+console.log(
+  util.inspect(summary, {
+    depth: null,
+    colors: true,
+    maxArrayLength: null,
+  }),
+);
+
+const changedCount = summary.filter((item) => item.changed).length;
+console.log(`\nLocale files processed: ${summary.length}`);
+console.log(`Locale files changed: ${changedCount}`);

--- a/containers/frontend/web/scripts/i18n/sort-locales.mjs
+++ b/containers/frontend/web/scripts/i18n/sort-locales.mjs
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import util from 'node:util';
 
 const ROOT_ORDER = ['common', 'components', 'layouts', 'pages', 'features', 'validation', 'errors'];

--- a/containers/frontend/web/src/i18n/messages/ca.json
+++ b/containers/frontend/web/src/i18n/messages/ca.json
@@ -11,24 +11,24 @@
       "me": "El Meu Compte",
       "reset-password": "Restablir Contrasenya"
     },
+    "footer": {
+      "appName": "Transcendence",
+      "copyright": "© {year} {appName}. Tots els drets reservats",
+      "github": "GitHub",
+      "privacy": "Política de Privacitat",
+      "terms": "Termes de Servei"
+    },
     "localeSwitcher": {
       "ariaLabel": "Idioma",
+      "ca": "CA",
       "en": "EN",
-      "es": "ES",
-      "ca": "CA"
+      "es": "ES"
     },
     "submitButton": {
       "pendingLabel": "CHANGE_LATER"
     },
     "textAreaField": {
       "characterCount": "{current} de {max} caràcters"
-    },
-    "footer": {
-      "appName": "Transcendence",
-      "privacy": "Política de Privacitat",
-      "terms": "Termes de Servei",
-      "github": "GitHub",
-      "copyright": "© {year} {appName}. Tots els drets reservats"
     }
   },
   "layouts": {
@@ -39,318 +39,318 @@
   },
   "pages": {
     "home": {
-      "title": "Hola des de Next en Docker 👋",
-      "subtitle": "Si veus això, l'enrutament i el servidor de desenvolupament funcionen."
-    },
-    "notFound": {
-      "title": "Pàgina no trobada",
-      "description": "La pàgina que busques no existeix.",
-      "backToHome": "Torna a l'inici"
+      "subtitle": "Si veus això, l'enrutament i el servidor de desenvolupament funcionen.",
+      "title": "Hola des de Next en Docker 👋"
     },
     "me": {
-      "title": "El Meu Compte",
-      "subtitle": "Accedeix a les dades protegides del teu compte."
+      "subtitle": "Accedeix a les dades protegides del teu compte.",
+      "title": "El Meu Compte"
+    },
+    "notFound": {
+      "backToHome": "Torna a l'inici",
+      "description": "La pàgina que busques no existeix.",
+      "title": "Pàgina no trobada"
     },
     "privacy": {
-      "title": "Política de Privacitat",
-      "lastUpdated": "Última actualització: Abril 2026",
-      "intro": "A Transcendence, valorem la teva privacitat. Aquesta política descriu quines dades recopilem, com les fem servir, com les emmagatzemem i quins drets tens sobre la teva informació personal.",
+      "contact": {
+        "description": "Si tens alguna pregunta sobre aquesta política o desitges exercir els teus drets, si us plau, contacta amb l'equip de desenvolupament a través del nostre <link>repositori de GitHub</link>.",
+        "title": "Contacte"
+      },
       "dataCollected": {
-        "title": "Dades Recopilades",
         "description": "Quan fas servir la nostra plataforma, podem recopilar la següent informació:",
         "items": {
           "email": "Adreça de correu electrònic (utilitzada per al registre i l'autenticació)",
-          "username": "Nom d'usuari (escollit per tu per identificar-te al joc)",
+          "technical": "Dades tècniques (tipus de navegador, informació del dispositiu i adreça IP amb fins de seguretat)",
           "usage": "Dades d'ús (historial de partides, puntuacions i registres d'interacció)",
-          "technical": "Dades tècniques (tipus de navegador, informació del dispositiu i adreça IP amb fins de seguretat)"
-        }
+          "username": "Nom d'usuari (escollit per tu per identificar-te al joc)"
+        },
+        "title": "Dades Recopilades"
       },
       "dataUsage": {
-        "title": "Com Fem Servir les Teves Dades",
         "description": "Les dades que recopilem s'utilitzen exclusivament per als següents fins:",
         "items": {
           "account": "Gestió de comptes i autenticació",
+          "communication": "Enviar comunicacions necessàries relacionades amb el teu compte",
           "gameplay": "Proporcionar l'experiència de joc i funcions socials",
-          "improvement": "Millorar i optimitzar la plataforma",
-          "communication": "Enviar comunicacions necessàries relacionades amb el teu compte"
-        }
+          "improvement": "Millorar i optimitzar la plataforma"
+        },
+        "title": "Com Fem Servir les Teves Dades"
       },
-      "storage": {
-        "title": "Emmagatzematge i Seguretat de Dades",
-        "description": "Les teves dades s'emmagatzemen de forma segura als nostres servidors. Implementem mesures de seguretat estàndard de la indústria, incloent connexions xifrades (HTTPS), hash segur de contrasenyes i auditories de seguretat regulars. Conservem les teves dades només mentre el teu compte estigui actiu o segons sigui necessari per proporcionar-te els nostres serveis."
-      },
+      "intro": "A Transcendence, valorem la teva privacitat. Aquesta política descriu quines dades recopilem, com les fem servir, com les emmagatzemem i quins drets tens sobre la teva informació personal.",
+      "lastUpdated": "Última actualització: Abril 2026",
       "rights": {
-        "title": "Els Teus Drets",
         "description": "Com a usuari, tens els següents drets sobre les teves dades personals:",
         "items": {
           "access": "Dret a accedir a les teves dades personals",
-          "rectification": "Dret a corregir dades inexactes",
           "deletion": "Dret a sol·licitar l'eliminació de les teves dades",
-          "portability": "Dret a la portabilitat de dades"
-        }
+          "portability": "Dret a la portabilitat de dades",
+          "rectification": "Dret a corregir dades inexactes"
+        },
+        "title": "Els Teus Drets"
       },
-      "contact": {
-        "title": "Contacte",
-        "description": "Si tens alguna pregunta sobre aquesta política o desitges exercir els teus drets, si us plau, contacta amb l'equip de desenvolupament a través del nostre <link>repositori de GitHub</link>."
-      }
+      "storage": {
+        "description": "Les teves dades s'emmagatzemen de forma segura als nostres servidors. Implementem mesures de seguretat estàndard de la indústria, incloent connexions xifrades (HTTPS), hash segur de contrasenyes i auditories de seguretat regulars. Conservem les teves dades només mentre el teu compte estigui actiu o segons sigui necessari per proporcionar-te els nostres serveis.",
+        "title": "Emmagatzematge i Seguretat de Dades"
+      },
+      "title": "Política de Privacitat"
     },
     "terms": {
-      "title": "Termes de Servei",
-      "lastUpdated": "Última actualització: Abril 2026",
-      "intro": "Benvingut a Transcendence. L'ús d'aquesta plataforma està subjecte als següents Termes de Servei, que regeixen la relació entre tu i l'equip de desenvolupament.",
       "acceptance": {
-        "title": "Acceptació dels Termes",
-        "description": "En crear un compte o utilitzar els nostres serveis, acceptes aquests Termes en la seva totalitat. Si no estàs d'acord amb alguna part, t'has d'abstenir d'utilitzar la plataforma."
-      },
-      "registration": {
-        "title": "Registre de Compte",
-        "description": "Ets responsable de mantenir la confidencialitat de les teves credencials i de totes les activitats que es produeixin sota el teu compte.",
-        "items": {
-          "security": "Ens has de notificar immediatament qualsevol ús no autoritzat del teu compte.",
-          "accuracy": "Acceptes proporcionar informació precisa i completa durant el registre."
-        }
+        "description": "En crear un compte o utilitzar els nostres serveis, acceptes aquests Termes en la seva totalitat. Si no estàs d'acord amb alguna part, t'has d'abstenir d'utilitzar la plataforma.",
+        "title": "Acceptació dels Termes"
       },
       "conduct": {
-        "title": "Conducta de l'Usuari",
         "description": "Per mantenir un entorn just, respectuós i divertit, et compromets a no:",
         "items": {
           "cheating": "Utilitzar trampes, programari d'automatització (bots) o hacks per obtenir avantatge.",
-          "harassment": "Assetjar, abusar o participar en conductes que danyin la comunitat o altres jugadors.",
-          "disruption": "Intentar interrompre la integritat o seguretat dels nostres servidors."
-        }
-      },
-      "ip": {
-        "title": "Propietat Intel·lectual",
-        "description": "Tot el contingut, incloent el codi del joc, gràfics i marques registrades, és propietat de Transcendence. Atorguem una llicència limitada i no transferible per a ús personal i no comercial."
-      },
-      "disclaimer": {
-        "title": "Exempció de responsabilitat",
-        "description": "Transcendence és un projecte educatiu i comunitari. En conseqüència, el servei es proporciona tal com està i segons disponibilitat. No garantim que el servei sigui ininterromput, puntual, segur o lliure d'errors."
-      },
-      "termination": {
-        "title": "Cancel·lació",
-        "description": "Ens reservem el dret de suspendre o tancar el teu compte a la nostra discreció, sense previ avís, per conductes que considerem que violen aquests Termes o que resultin perjudicials per a altres usuaris o el projecte."
-      },
-      "law": {
-        "title": "Llei Aplicable",
-        "description": "Aquests Termes es regeixen i interpreten d'acord amb les lleis aplicables als serveis digitals dins de l'àmbit de jurisdicció d'aquest projecte."
+          "disruption": "Intentar interrompre la integritat o seguretat dels nostres servidors.",
+          "harassment": "Assetjar, abusar o participar en conductes que danyin la comunitat o altres jugadors."
+        },
+        "title": "Conducta de l'Usuari"
       },
       "contact": {
-        "title": "Contacte",
-        "description": "Si tens preguntes o desitges exercir qualsevol dret relacionat amb aquests Termes, si us plau, contacta amb l'equip obrint una incidència en el nostre <link>repositori de GitHub</link>."
-      }
+        "description": "Si tens preguntes o desitges exercir qualsevol dret relacionat amb aquests Termes, si us plau, contacta amb l'equip obrint una incidència en el nostre <link>repositori de GitHub</link>.",
+        "title": "Contacte"
+      },
+      "disclaimer": {
+        "description": "Transcendence és un projecte educatiu i comunitari. En conseqüència, el servei es proporciona tal com està i segons disponibilitat. No garantim que el servei sigui ininterromput, puntual, segur o lliure d'errors.",
+        "title": "Exempció de responsabilitat"
+      },
+      "intro": "Benvingut a Transcendence. L'ús d'aquesta plataforma està subjecte als següents Termes de Servei, que regeixen la relació entre tu i l'equip de desenvolupament.",
+      "ip": {
+        "description": "Tot el contingut, incloent el codi del joc, gràfics i marques registrades, és propietat de Transcendence. Atorguem una llicència limitada i no transferible per a ús personal i no comercial.",
+        "title": "Propietat Intel·lectual"
+      },
+      "lastUpdated": "Última actualització: Abril 2026",
+      "law": {
+        "description": "Aquests Termes es regeixen i interpreten d'acord amb les lleis aplicables als serveis digitals dins de l'àmbit de jurisdicció d'aquest projecte.",
+        "title": "Llei Aplicable"
+      },
+      "registration": {
+        "description": "Ets responsable de mantenir la confidencialitat de les teves credencials i de totes les activitats que es produeixin sota el teu compte.",
+        "items": {
+          "accuracy": "Acceptes proporcionar informació precisa i completa durant el registre.",
+          "security": "Ens has de notificar immediatament qualsevol ús no autoritzat del teu compte."
+        },
+        "title": "Registre de Compte"
+      },
+      "termination": {
+        "description": "Ens reservem el dret de suspendre o tancar el teu compte a la nostra discreció, sense previ avís, per conductes que considerem que violen aquests Termes o que resultin perjudicials per a altres usuaris o el projecte.",
+        "title": "Cancel·lació"
+      },
+      "title": "Termes de Servei"
     }
   },
   "features": {
     "auth": {
+      "actions": {
+        "continueWithGoogle": "Continuar amb Google",
+        "login": "Iniciar sessió",
+        "logoutAriaLabel": "Tancar sessió",
+        "resendEmail": "Tornar a enviar el correu",
+        "sendEmail": "Enviar correu electrònic",
+        "signup": "Crear compte"
+      },
+      "changePassword": {
+        "description": "Introdueix la teva contrasenya actual i tria'n una de nova.",
+        "submit": "Desa els canvis",
+        "success": "La contrasenya s'ha actualitzat correctament.",
+        "title": "Canvia la contrasenya"
+      },
       "fields": {
-        "identifier": {
-          "label": "Correu o nom d'usuari",
-          "placeholder": "nom@exemple.com o usuari",
-          "description": "Utilitza el correu o el nom d'usuari amb el qual et vas registrar."
-        },
-        "email": {
-          "label": "Correu electrònic",
-          "placeholder": "nom@exemple.com"
-        },
-        "username": {
-          "label": "Nom d'usuari",
-          "placeholder": "el_teu_usuari"
-        },
-        "password": {
-          "label": "Contrasenya",
-          "placeholder": "Introdueix la teva contrasenya",
-          "description": "Mínim 8 caràcters."
+        "confirmPassword": {
+          "label": "Confirmar contrasenya",
+          "placeholder": "Torna a introduir la teva contrasenya"
         },
         "currentPassword": {
           "label": "Contrasenya actual",
           "placeholder": "Introdueix la teva contrasenya actual"
         },
-        "newPassword": {
-          "label": "Contrasenya nova",
-          "placeholder": "Introdueix la teva contrasenya nova",
-          "description": "Mínim 8 caràcters."
+        "email": {
+          "label": "Correu electrònic",
+          "placeholder": "nom@exemple.com"
         },
-        "confirmPassword": {
-          "label": "Confirmar contrasenya",
-          "placeholder": "Torna a introduir la teva contrasenya"
+        "identifier": {
+          "description": "Utilitza el correu o el nom d'usuari amb el qual et vas registrar.",
+          "label": "Correu o nom d'usuari",
+          "placeholder": "nom@exemple.com o usuari"
+        },
+        "newPassword": {
+          "description": "Mínim 8 caràcters.",
+          "label": "Contrasenya nova",
+          "placeholder": "Introdueix la teva contrasenya nova"
+        },
+        "password": {
+          "description": "Mínim 8 caràcters.",
+          "label": "Contrasenya",
+          "placeholder": "Introdueix la teva contrasenya"
+        },
+        "username": {
+          "label": "Nom d'usuari",
+          "placeholder": "el_teu_usuari"
         }
       },
-      "actions": {
-        "login": "Iniciar sessió",
-        "signup": "Crear compte",
-        "continueWithGoogle": "Continuar amb Google",
-        "sendEmail": "Enviar correu electrònic",
-        "resendEmail": "Tornar a enviar el correu",
-        "logoutAriaLabel": "Tancar sessió"
-      },
       "login": {
-        "title": "Iniciar sessió",
-        "submit": "Iniciar sessió",
         "forgotPassword": "Has oblidat la contrasenya?",
+        "goToSignup": "Crear-ne un",
         "noAccount": "No tens compte?",
-        "goToSignup": "Crear-ne un"
-      },
-      "signup": {
-        "title": "Crear compte",
-        "privacy": {
-          "label": "He llegit i accepto la <link>Política de Privacitat</link>",
-          "error": "Has d'acceptar la Política de Privacitat per continuar."
-        },
-        "haveAccount": "Ja tens compte?",
-        "goToLogin": "Iniciar sessió"
-      },
-      "verification": {
-        "title": "Verifica el teu correu electrònic",
-        "sent": "T'hem enviat un correu per confirmar el teu compte.",
-        "checkInbox": "Revisa la teva safata d'entrada i segueix les instruccions per activar el teu compte.",
-        "checkSpam": "Si no el trobes, revisa la carpeta de correu brossa. Si tampoc hi és, pots tornar a enviar-lo.",
-        "verifying": "Verificant el teu correu...",
-        "verified": "Correu verificat. Redirigint al teu perfil...",
-        "missingToken": "Falta el token de verificació.",
-        "invalidOrExpired": "L'enllaç de verificació no és vàlid o ha caducat.",
-        "resending": "Enviant...",
-        "isConfirmed": "Ja has confirmat?",
-        "backToLogin": "Iniciar sessió",
-        "recoverTitle": "Recuperar compte",
-        "resendTitle": "Torna a enviar el correu de verificació",
-        "resendDescription": "Introdueix el correu electrònic que vas fer servir per crear el teu compte."
-      },
-      "recover": {
-        "title": "Revisa el teu correu",
-        "sent": "T'hem enviat instruccions per restablir la contrasenya al correu que has introduït.",
-        "checkInbox": "Revisa la teva safata d'entrada i segueix les instruccions per crear una nova contrasenya.",
-        "checkSpam": "Si no el trobes, revisa la carpeta de correu brossa. Si tampoc hi és, prova-ho de nou més tard.",
-        "rememberedPassword": "Has recordat la teva contrasenya?",
-        "backToLogin": "Torna a iniciar sessió"
-      },
-      "reset": {
-        "title": "Restableix la contrasenya",
-        "description": "Introdueix la teva nova contrasenya.",
-        "submit": "Desa la contrasenya nova",
-        "success": "La contrasenya s'ha actualitzat correctament.",
-        "rememberedPassword": "Has recordat la contrasenya?",
-        "backToLogin": "Torna a iniciar sessió"
-      },
-      "changePassword": {
-        "title": "Canvia la contrasenya",
-        "description": "Introdueix la teva contrasenya actual i tria'n una de nova.",
-        "submit": "Desa els canvis",
-        "success": "La contrasenya s'ha actualitzat correctament."
+        "submit": "Iniciar sessió",
+        "title": "Iniciar sessió"
       },
       "messages": {
         "or": "O",
         "success": "Correu enviat. Espera per tornar-ho a intentar."
+      },
+      "recover": {
+        "backToLogin": "Torna a iniciar sessió",
+        "checkInbox": "Revisa la teva safata d'entrada i segueix les instruccions per crear una nova contrasenya.",
+        "checkSpam": "Si no el trobes, revisa la carpeta de correu brossa. Si tampoc hi és, prova-ho de nou més tard.",
+        "rememberedPassword": "Has recordat la teva contrasenya?",
+        "sent": "T'hem enviat instruccions per restablir la contrasenya al correu que has introduït.",
+        "title": "Revisa el teu correu"
+      },
+      "reset": {
+        "backToLogin": "Torna a iniciar sessió",
+        "description": "Introdueix la teva nova contrasenya.",
+        "rememberedPassword": "Has recordat la contrasenya?",
+        "submit": "Desa la contrasenya nova",
+        "success": "La contrasenya s'ha actualitzat correctament.",
+        "title": "Restableix la contrasenya"
+      },
+      "signup": {
+        "goToLogin": "Iniciar sessió",
+        "haveAccount": "Ja tens compte?",
+        "privacy": {
+          "error": "Has d'acceptar la Política de Privacitat per continuar.",
+          "label": "He llegit i accepto la <link>Política de Privacitat</link>"
+        },
+        "title": "Crear compte"
+      },
+      "verification": {
+        "backToLogin": "Iniciar sessió",
+        "checkInbox": "Revisa la teva safata d'entrada i segueix les instruccions per activar el teu compte.",
+        "checkSpam": "Si no el trobes, revisa la carpeta de correu brossa. Si tampoc hi és, pots tornar a enviar-lo.",
+        "invalidOrExpired": "L'enllaç de verificació no és vàlid o ha caducat.",
+        "isConfirmed": "Ja has confirmat?",
+        "missingToken": "Falta el token de verificació.",
+        "recoverTitle": "Recuperar compte",
+        "resendDescription": "Introdueix el correu electrònic que vas fer servir per crear el teu compte.",
+        "resending": "Enviant...",
+        "resendTitle": "Torna a enviar el correu de verificació",
+        "sent": "T'hem enviat un correu per confirmar el teu compte.",
+        "title": "Verifica el teu correu electrònic",
+        "verified": "Correu verificat. Redirigint al teu perfil...",
+        "verifying": "Verificant el teu correu..."
       }
     },
-    "navigation": {
-      "home": "Inici",
-      "createAccount": "Crear compte",
-      "login": "Iniciar sessió",
-      "menu": "Menú",
-      "mainAriaLabel": "Navegació principal",
-      "ui": "UI",
-      "game": "Joc",
-      "profile": "Perfil",
-      "logout": "Tancar sessió",
-      "settings": "Configuració"
-    },
     "chat": {
+      "hideChat": "Amaga el xat",
       "messageAriaLabel": "Missatge",
-      "showChat": "Mostra el xat",
-      "hideChat": "Amaga el xat"
+      "showChat": "Mostra el xat"
     },
     "game": {
-      "resetPlan": "Reiniciar pla",
       "endTurn": "Acabar torn",
-      "healthLabel": "HP"
+      "healthLabel": "HP",
+      "resetPlan": "Reiniciar pla"
     },
-    "settings": {
-      "theme": "Tema",
-      "language": "Idioma",
-      "dark": "Fosc",
-      "light": "Clar"
+    "navigation": {
+      "createAccount": "Crear compte",
+      "game": "Joc",
+      "home": "Inici",
+      "login": "Iniciar sessió",
+      "logout": "Tancar sessió",
+      "mainAriaLabel": "Navegació principal",
+      "menu": "Menú",
+      "profile": "Perfil",
+      "settings": "Configuració",
+      "ui": "UI"
     },
     "profile": {
-      "fail": "No s'ha pogut carregar el teu perfil.",
-      "userId": "ID d'usuari",
-      "username": "Nom d'usuari",
       "bio": "Biografia",
-      "provider": "Proveïdor"
+      "fail": "No s'ha pogut carregar el teu perfil.",
+      "provider": "Proveïdor",
+      "userId": "ID d'usuari",
+      "username": "Nom d'usuari"
+    },
+    "settings": {
+      "dark": "Fosc",
+      "language": "Idioma",
+      "light": "Clar",
+      "theme": "Tema"
     },
     "social": {
-      "title": "Social",
-      "searchPlaceholder": "Cerca usuaris",
-      "searchLabel": "Cercador",
-      "friends": {
-        "title": "Amics",
-        "online": "Amics connectats",
-        "offline": "Amics desconnectats"
-      },
-      "requests": {
-        "title": "Sol·licituds",
-        "received": "Rebudes",
-        "sent": "Enviades"
+      "actions": {
+        "accept": "Acceptar",
+        "addFriend": "Afegir amic",
+        "cancel": "Cancel·lar",
+        "chat": "Chat",
+        "inviteToGame": "Convidar a partida",
+        "reject": "Rebutjar"
       },
       "emptyStates": {
-        "online": "No hi ha amics connectats",
         "offline": "No hi ha amics desconnectats",
-        "request": "No tens sol·licituds pendents",
+        "online": "No hi ha amics connectats",
         "pending": "No has enviat sol·licituds",
+        "request": "No tens sol·licituds pendents",
         "search": "No s’han trobat usuaris"
       },
-      "actions": {
-        "inviteToGame": "Convidar a partida",
-        "chat": "Chat",
-        "reject": "Rebutjar",
-        "accept": "Acceptar",
-        "cancel": "Cancel·lar",
-        "addFriend": "Afegir amic"
+      "friends": {
+        "offline": "Amics desconnectats",
+        "online": "Amics connectats",
+        "title": "Amics"
       },
       "guest": {
-        "title": "Connecta amb la comunitat",
         "body": "Per trobar amics, veure qui està connectat i jugar, necessites un compte.",
         "login": "Iniciar sessió",
         "noAccount": "No tens compte?",
-        "signup": "Crear-ne un"
-      }
+        "signup": "Crear-ne un",
+        "title": "Connecta amb la comunitat"
+      },
+      "requests": {
+        "received": "Rebudes",
+        "sent": "Enviades",
+        "title": "Sol·licituds"
+      },
+      "searchLabel": "Cercador",
+      "searchPlaceholder": "Cerca usuaris",
+      "title": "Social"
     }
   },
   "validation": {
-    "REQUIRED": "Aquest camp és obligatori.",
+    "FIELD_TOO_LONG": "Massa llarg.",
+    "FIELD_TOO_SHORT": "Massa curt.",
     "INVALID_EMAIL": "Introdueix un correu electrònic vàlid.",
-    "INVALID_USERNAME": "El nom d'usuari ha de tenir entre 3 i 30 caràcters i només pot contenir lletres, números, guions baixos (_) o guions (-).",
     "INVALID_EMAIL_OR_USERNAME": "Introdueix un correu electrònic o nom d'usuari vàlid.",
     "INVALID_FORMAT": "Format no vàlid.",
-    "USERNAME_TOO_SHORT": "El nom d'usuari ha de tenir almenys 3 caràcters.",
-    "USERNAME_TOO_LONG": "El nom d'usuari no pot superar els 30 caràcters.",
+    "INVALID_USERNAME": "El nom d'usuari ha de tenir entre 3 i 30 caràcters i només pot contenir lletres, números, guions baixos (_) o guions (-).",
     "INVALID_USERNAME_FORMAT": "El nom d'usuari només pot contenir lletres, números, guions baixos (_) i guions (-).",
-    "FIELD_TOO_SHORT": "Massa curt.",
-    "FIELD_TOO_LONG": "Massa llarg.",
+    "OUT_OF_RANGE": "Sol·licitud fora de rang",
     "PASSWORDS_DO_NOT_MATCH": "Les contrasenyes no coincideixen.",
-    "OUT_OF_RANGE": "Sol·licitud fora de rang"
+    "REQUIRED": "Aquest camp és obligatori.",
+    "USERNAME_TOO_LONG": "El nom d'usuari no pot superar els 30 caràcters.",
+    "USERNAME_TOO_SHORT": "El nom d'usuari ha de tenir almenys 3 caràcters."
   },
   "errors": {
-    "AUTH_EMAIL_ALREADY_EXISTS": "Aquest correu electrònic ja existeix",
-    "AUTH_INVALID_CREDENTIALS": "Credencials no vàlides",
     "AUTH_ACCOUNT_LOCKED": "El teu compte està bloquejat temporalment. Torna-ho a provar més tard.",
-    "AUTH_RATE_LIMITED": "Massa intents. Torna-ho a provar més tard.",
-    "AUTH_NO_PENDING_RECOVER": "No s'ha trobat cap sol·licitud de restabliment. Torna a començar.",
+    "AUTH_EMAIL_ALREADY_EXISTS": "Aquest correu electrònic ja existeix",
     "AUTH_EMAIL_NOT_VERIFIED": "Verifica el teu correu abans d'iniciar sessió.",
-    "AUTH_TOKEN_EXPIRED": "L'enllaç de verificació no és vàlid o ha caducat.",
-    "AUTH_UNAUTHORIZED": "Has d'iniciar sessió per veure aquest contingut.",
     "AUTH_FORBIDDEN": "No tens permís per accedir a aquest recurs.",
     "AUTH_INTERNAL_ERROR": "Alguna cosa ha anat malament. Torna-ho a provar.",
-    "VALIDATION_ERROR": "Error de validació: revisa els camps i intenta de nou.",
+    "AUTH_INVALID_CREDENTIALS": "Credencials no vàlides",
+    "AUTH_NO_PENDING_RECOVER": "No s'ha trobat cap sol·licitud de restabliment. Torna a començar.",
+    "AUTH_RATE_LIMITED": "Massa intents. Torna-ho a provar més tard.",
+    "AUTH_TOKEN_EXPIRED": "L'enllaç de verificació no és vàlid o ha caducat.",
+    "AUTH_UNAUTHORIZED": "Has d'iniciar sessió per veure aquest contingut.",
     "FETCH_FAILED": "Ha fallat la sol·licitud a l'API. Torna-ho a provar més tard.",
-    "UNAUTHORIZED_ACTION": "Acció no permesa.",
-    "FRIENDSHIP_REQUEST_NOT_FOUND": "La sol·licitud no existeix o ja no està disponible.",
     "FRIENDSHIP_ALREADY_ACCEPTED": "Aquesta sol·licitud ja ha estat acceptada.",
-    "FRIENDSHIP_NOT_FOUND": "No s'ha trobat l'amistat.",
-    "USER_NOT_FOUND": "Usuari no trobat.",
-    "INTERNAL_ERROR": "Alguna cosa ha anat malament. Torna-ho a provar.",
     "FRIENDSHIP_ALREADY_EXISTS": "Ja sou amics.",
+    "FRIENDSHIP_NOT_FOUND": "No s'ha trobat l'amistat.",
+    "FRIENDSHIP_REQUEST_ALREADY_SENT": "Ja s'ha enviat una sol·licitud d'amistat.",
+    "FRIENDSHIP_REQUEST_NOT_FOUND": "La sol·licitud no existeix o ja no està disponible.",
     "FRIENDSHIP_SELF_REQUEST": "No et pots afegir a tu mateix.",
-    "FRIENDSHIP_REQUEST_ALREADY_SENT": "Ja s'ha enviat una sol·licitud d'amistat."
+    "INTERNAL_ERROR": "Alguna cosa ha anat malament. Torna-ho a provar.",
+    "UNAUTHORIZED_ACTION": "Acció no permesa.",
+    "USER_NOT_FOUND": "Usuari no trobat.",
+    "VALIDATION_ERROR": "Error de validació: revisa els camps i intenta de nou."
   }
 }

--- a/containers/frontend/web/src/i18n/messages/en.d.json.ts
+++ b/containers/frontend/web/src/i18n/messages/en.d.json.ts
@@ -14,24 +14,24 @@ declare const messages: {
       "me": "My Account",
       "reset-password": "Reset Password"
     },
-    "submitButton": {
-      "pendingLabel": "Submitting..."
+    "footer": {
+      "appName": "Transcendence",
+      "copyright": "© {year} {appName}. All rights reserved",
+      "github": "GitHub",
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Service"
     },
     "localeSwitcher": {
       "ariaLabel": "Language",
+      "ca": "CA",
       "en": "EN",
-      "es": "ES",
-      "ca": "CA"
+      "es": "ES"
+    },
+    "submitButton": {
+      "pendingLabel": "Submitting..."
     },
     "textAreaField": {
       "characterCount": "{current} of {max} characters"
-    },
-    "footer": {
-      "appName": "Transcendence",
-      "privacy": "Privacy Policy",
-      "terms": "Terms of Service",
-      "github": "GitHub",
-      "copyright": "© {year} {appName}. All rights reserved"
     }
   },
   "layouts": {
@@ -42,319 +42,319 @@ declare const messages: {
   },
   "pages": {
     "home": {
-      "title": "Hello from Next in Docker 👋",
-      "subtitle": "If you can see this, routing + dev server work."
-    },
-    "notFound": {
-      "title": "Page not found",
-      "description": "The page you're looking for doesn't exist.",
-      "backToHome": "Back to Home"
+      "subtitle": "If you can see this, routing + dev server work.",
+      "title": "Hello from Next in Docker 👋"
     },
     "me": {
-      "title": "My Account",
-      "subtitle": "Access your protected account data."
+      "subtitle": "Access your protected account data.",
+      "title": "My Account"
+    },
+    "notFound": {
+      "backToHome": "Back to Home",
+      "description": "The page you're looking for doesn't exist.",
+      "title": "Page not found"
     },
     "privacy": {
-      "title": "Privacy Policy",
-      "lastUpdated": "Last updated: April 2026",
-      "intro": "At Transcendence, we value your privacy. This policy describes what data we collect, how we use it, how we store it, and what rights you have regarding your personal information.",
+      "contact": {
+        "description": "If you have any questions about this policy or wish to exercise your rights, please contact the development team through our <link>GitHub repository</link>.",
+        "title": "Contact"
+      },
       "dataCollected": {
-        "title": "Data Collected",
         "description": "When you use our platform, we may collect the following information:",
         "items": {
           "email": "Email address (used for account registration and authentication)",
-          "username": "Username (chosen by you to identify yourself in the game)",
+          "technical": "Technical data (browser type, device information, and IP address for security purposes)",
           "usage": "Usage data (game history, scores, and interaction logs)",
-          "technical": "Technical data (browser type, device information, and IP address for security purposes)"
-        }
+          "username": "Username (chosen by you to identify yourself in the game)"
+        },
+        "title": "Data Collected"
       },
       "dataUsage": {
-        "title": "How We Use Your Data",
         "description": "The data we collect is used exclusively for the following purposes:",
         "items": {
           "account": "Account management and authentication",
+          "communication": "Sending necessary communications related to your account",
           "gameplay": "Providing the game experience and social features",
-          "improvement": "Improving and optimizing the platform",
-          "communication": "Sending necessary communications related to your account"
-        }
+          "improvement": "Improving and optimizing the platform"
+        },
+        "title": "How We Use Your Data"
       },
-      "storage": {
-        "title": "Data Storage and Security",
-        "description": "Your data is stored securely on our servers. We implement industry-standard security measures including encrypted connections (HTTPS), secure password hashing, and regular security audits. We retain your data only for as long as your account is active or as needed to provide you with our services."
-      },
+      "intro": "At Transcendence, we value your privacy. This policy describes what data we collect, how we use it, how we store it, and what rights you have regarding your personal information.",
+      "lastUpdated": "Last updated: April 2026",
       "rights": {
-        "title": "Your Rights",
         "description": "As a user, you have the following rights regarding your personal data:",
         "items": {
           "access": "Right to access your personal data",
-          "rectification": "Right to correct inaccurate data",
           "deletion": "Right to request deletion of your data",
-          "portability": "Right to data portability"
-        }
+          "portability": "Right to data portability",
+          "rectification": "Right to correct inaccurate data"
+        },
+        "title": "Your Rights"
       },
-      "contact": {
-        "title": "Contact",
-        "description": "If you have any questions about this policy or wish to exercise your rights, please contact the development team through our <link>GitHub repository</link>."
-      }
+      "storage": {
+        "description": "Your data is stored securely on our servers. We implement industry-standard security measures including encrypted connections (HTTPS), secure password hashing, and regular security audits. We retain your data only for as long as your account is active or as needed to provide you with our services.",
+        "title": "Data Storage and Security"
+      },
+      "title": "Privacy Policy"
     },
     "terms": {
-      "title": "Terms of Service",
-      "lastUpdated": "Last updated: April 2026",
-      "intro": "Welcome to Transcendence. Your use of this platform is subject to the following Terms of Service, which govern the relationship between you and the development team.",
       "acceptance": {
-        "title": "Acceptance of Terms",
-        "description": "By creating an account or using our services, you agree to these conditions in their entirety. If you do not agree with any part of these Terms, you must refrain from using the platform."
-      },
-      "registration": {
-        "title": "Account Registration",
-        "description": "You are responsible for maintaining the confidentiality of your credentials and for all activities that occur under your account.",
-        "items": {
-          "security": "You must notify us immediately of any unauthorized use of your account.",
-          "accuracy": "You agree to provide accurate and complete information during registration."
-        }
+        "description": "By creating an account or using our services, you agree to these conditions in their entirety. If you do not agree with any part of these Terms, you must refrain from using the platform.",
+        "title": "Acceptance of Terms"
       },
       "conduct": {
-        "title": "User Conduct",
         "description": "To maintain a fair, respectful, and fun environment, you agree not to:",
         "items": {
           "cheating": "Use cheats, automation software (bots), or hacks to gain an advantage.",
-          "harassment": "Harass, abuse, or engage in behavior that harms the community or other players.",
-          "disruption": "Attempt to disrupt the integrity or security of our servers."
-        }
-      },
-      "ip": {
-        "title": "Intellectual Property",
-        "description": "All content, including game code, graphics, and trademarks, is the property of Transcendence. We grant you a limited, non-transferable license for personal, non-commercial use."
-      },
-      "disclaimer": {
-        "title": "Disclaimers",
-        "description": "Transcendence is an educational and community-driven project. Consequently, the service is provided as is and as available. We do not warrant that the service will be uninterrupted, timely, secure, or error-free."
-      },
-      "termination": {
-        "title": "Termination",
-        "description": "We reserve the right to suspend or terminate your account at our sole discretion, without notice, for conduct that we believe violates these Terms or is harmful to other users, us, or third parties."
-      },
-      "law": {
-        "title": "Governing Law",
-        "description": "These Terms shall be governed by and construed in accordance with the laws applicable to digital services within the scope of this project's jurisdiction."
+          "disruption": "Attempt to disrupt the integrity or security of our servers.",
+          "harassment": "Harass, abuse, or engage in behavior that harms the community or other players."
+        },
+        "title": "User Conduct"
       },
       "contact": {
-        "title": "Contact Us",
-        "description": "If you have any questions or wish to exercise your rights, please contact the development team by opening an issue on our <link>GitHub repository</link>."
-      }
+        "description": "If you have any questions or wish to exercise your rights, please contact the development team by opening an issue on our <link>GitHub repository</link>.",
+        "title": "Contact Us"
+      },
+      "disclaimer": {
+        "description": "Transcendence is an educational and community-driven project. Consequently, the service is provided as is and as available. We do not warrant that the service will be uninterrupted, timely, secure, or error-free.",
+        "title": "Disclaimers"
+      },
+      "intro": "Welcome to Transcendence. Your use of this platform is subject to the following Terms of Service, which govern the relationship between you and the development team.",
+      "ip": {
+        "description": "All content, including game code, graphics, and trademarks, is the property of Transcendence. We grant you a limited, non-transferable license for personal, non-commercial use.",
+        "title": "Intellectual Property"
+      },
+      "lastUpdated": "Last updated: April 2026",
+      "law": {
+        "description": "These Terms shall be governed by and construed in accordance with the laws applicable to digital services within the scope of this project's jurisdiction.",
+        "title": "Governing Law"
+      },
+      "registration": {
+        "description": "You are responsible for maintaining the confidentiality of your credentials and for all activities that occur under your account.",
+        "items": {
+          "accuracy": "You agree to provide accurate and complete information during registration.",
+          "security": "You must notify us immediately of any unauthorized use of your account."
+        },
+        "title": "Account Registration"
+      },
+      "termination": {
+        "description": "We reserve the right to suspend or terminate your account at our sole discretion, without notice, for conduct that we believe violates these Terms or is harmful to other users, us, or third parties.",
+        "title": "Termination"
+      },
+      "title": "Terms of Service"
     }
   },
   "features": {
     "auth": {
+      "actions": {
+        "continueWithGoogle": "Continue with Google",
+        "login": "Log in",
+        "logoutAriaLabel": "Log out",
+        "resendEmail": "Resend email",
+        "sendEmail": "Send email",
+        "signup": "Create account"
+      },
+      "changePassword": {
+        "description": "Enter your current password and choose a new one.",
+        "submit": "Save changes",
+        "success": "Password updated successfully.",
+        "title": "Change password"
+      },
       "fields": {
-        "identifier": {
-          "label": "Email or username",
-          "placeholder": "name@example.com or username",
-          "description": "Use the email address or username you signed up with."
-        },
-        "email": {
-          "label": "Email",
-          "placeholder": "name@example.com"
-        },
-        "username": {
-          "label": "Username",
-          "placeholder": "your_username"
-        },
-        "password": {
-          "label": "Password",
-          "placeholder": "Enter your password",
-          "description": "Min 8 characters long."
+        "confirmPassword": {
+          "label": "Confirm password",
+          "placeholder": "Re-enter your password"
         },
         "currentPassword": {
           "label": "Current password",
           "placeholder": "Enter your current password"
         },
-        "newPassword": {
-          "label": "New password",
-          "placeholder": "Enter your new password",
-          "description": "Min 8 characters long."
+        "email": {
+          "label": "Email",
+          "placeholder": "name@example.com"
         },
-        "confirmPassword": {
-          "label": "Confirm password",
-          "placeholder": "Re-enter your password"
+        "identifier": {
+          "description": "Use the email address or username you signed up with.",
+          "label": "Email or username",
+          "placeholder": "name@example.com or username"
+        },
+        "newPassword": {
+          "description": "Min 8 characters long.",
+          "label": "New password",
+          "placeholder": "Enter your new password"
+        },
+        "password": {
+          "description": "Min 8 characters long.",
+          "label": "Password",
+          "placeholder": "Enter your password"
+        },
+        "username": {
+          "label": "Username",
+          "placeholder": "your_username"
         }
       },
-      "actions": {
-        "login": "Log in",
-        "signup": "Create account",
-        "continueWithGoogle": "Continue with Google",
-        "sendEmail": "Send email",
-        "resendEmail": "Resend email",
-        "logoutAriaLabel": "Log out"
-      },
       "login": {
-        "title": "Log in",
-        "submit": "Log in",
         "forgotPassword": "Forgot password?",
+        "goToSignup": "Create one",
         "noAccount": "Don’t have an account?",
-        "goToSignup": "Create one"
-      },
-      "signup": {
-        "title": "Create account",
-        "privacy": {
-          "label": "I have read and agree to the <link>Privacy Policy</link>",
-          "error": "You must accept the Privacy Policy to continue."
-        },
-        "haveAccount": "Already have an account?",
-        "goToLogin": "Log in"
-      },
-      "verification": {
-        "title": "Check your email",
-        "sent": "We've sent you an email to confirm your account.",
-        "checkInbox": "Check your inbox and follow the instructions to activate your account.",
-        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, you can resend it.",
-        "verifying": "Verifying your email...",
-        "verified": "Email verified. Redirecting to your profile...",
-        "missingToken": "Verification token is missing.",
-        "invalidOrExpired": "Verification link is invalid or expired.",
-        "resending": "Sending...",
-        "isConfirmed": "Already confirmed?",
-        "backToLogin": "Log In",
-        "recoverTitle": "Recover account",
-        "resendTitle": "Resend verification email",
-        "resendDescription": "Enter the email address you used to create your account."
-      },
-      "recover": {
-        "title": "Check your email",
-        "sent": "We've sent password reset instructions to the address you entered.",
-        "checkInbox": "Check your inbox and follow the instructions to set a new password.",
-        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, try again later.",
-        "rememberedPassword": "Remembered your password?",
-        "backToLogin": "Back to login"
-      },
-      "reset": {
-        "title": "Reset password",
-        "description": "Enter your new password.",
-        "submit": "Save new password",
-        "success": "Password updated successfully.",
-        "backToLogin": "Back to login"
-      },
-      "changePassword": {
-        "title": "Change password",
-        "description": "Enter your current password and choose a new one.",
-        "submit": "Save changes",
-        "success": "Password updated successfully."
+        "submit": "Log in",
+        "title": "Log in"
       },
       "messages": {
         "or": "OR",
         "success": "Email sent. Wait before trying again."
+      },
+      "recover": {
+        "backToLogin": "Back to login",
+        "checkInbox": "Check your inbox and follow the instructions to set a new password.",
+        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, try again later.",
+        "rememberedPassword": "Remembered your password?",
+        "sent": "We've sent password reset instructions to the address you entered.",
+        "title": "Check your email"
+      },
+      "reset": {
+        "backToLogin": "Back to login",
+        "description": "Enter your new password.",
+        "submit": "Save new password",
+        "success": "Password updated successfully.",
+        "title": "Reset password"
+      },
+      "signup": {
+        "goToLogin": "Log in",
+        "haveAccount": "Already have an account?",
+        "privacy": {
+          "error": "You must accept the Privacy Policy to continue.",
+          "label": "I have read and agree to the <link>Privacy Policy</link>"
+        },
+        "title": "Create account"
+      },
+      "verification": {
+        "backToLogin": "Log In",
+        "checkInbox": "Check your inbox and follow the instructions to activate your account.",
+        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, you can resend it.",
+        "invalidOrExpired": "Verification link is invalid or expired.",
+        "isConfirmed": "Already confirmed?",
+        "missingToken": "Verification token is missing.",
+        "recoverTitle": "Recover account",
+        "resendDescription": "Enter the email address you used to create your account.",
+        "resending": "Sending...",
+        "resendTitle": "Resend verification email",
+        "sent": "We've sent you an email to confirm your account.",
+        "title": "Check your email",
+        "verified": "Email verified. Redirecting to your profile...",
+        "verifying": "Verifying your email..."
       }
     },
-    "navigation": {
-      "home": "Home",
-      "createAccount": "Create account",
-      "login": "Log in",
-      "menu": "Menu",
-      "mainAriaLabel": "Main navigation",
-      "ui": "UI",
-      "game": "Game",
-      "profile": "Profile",
-      "logout": "Logout",
-      "settings": "Settings"
-    },
     "chat": {
+      "hideChat": "Hide Chat",
       "messageAriaLabel": "Message",
-      "showChat": "Show Chat",
-      "hideChat": "Hide Chat"
+      "showChat": "Show Chat"
     },
     "game": {
-      "resetPlan": "Reset plan",
       "endTurn": "End turn",
-      "healthLabel": "HP"
+      "healthLabel": "HP",
+      "resetPlan": "Reset plan"
     },
-    "settings": {
-      "theme": "Theme",
-      "language": "Language",
-      "dark": "Dark",
-      "light": "Light"
+    "navigation": {
+      "createAccount": "Create account",
+      "game": "Game",
+      "home": "Home",
+      "login": "Log in",
+      "logout": "Logout",
+      "mainAriaLabel": "Main navigation",
+      "menu": "Menu",
+      "profile": "Profile",
+      "settings": "Settings",
+      "ui": "UI"
     },
     "profile": {
-      "fail": "Could not load your profile.",
-      "userId": "User ID",
-      "username": "Username",
       "bio": "Bio",
-      "provider": "Provider"
+      "fail": "Could not load your profile.",
+      "provider": "Provider",
+      "userId": "User ID",
+      "username": "Username"
+    },
+    "settings": {
+      "dark": "Dark",
+      "language": "Language",
+      "light": "Light",
+      "theme": "Theme"
     },
     "social": {
-      "title": "Social",
-      "searchPlaceholder": "Search users",
-      "searchLabel": "Search",
-      "friends": {
-        "title": "Friends",
-        "online": "Friends online",
-        "offline": "Friends offline"
-      },
-      "requests": {
-        "title": "Requests",
-        "received": "Received",
-        "sent": "Sent"
+      "actions": {
+        "accept": "Accept",
+        "addFriend": "Add friend",
+        "cancel": "Cancel",
+        "chat": "Chat",
+        "inviteToGame": "Invite to Game",
+        "reject": "Reject"
       },
       "emptyStates": {
-        "online": "No friends online right now",
         "offline": "No friends offline",
-        "request": "No pending friend requests",
+        "online": "No friends online right now",
         "pending": "No sent requests pending",
+        "request": "No pending friend requests",
         "search": "No users found"
       },
-      "actions": {
-        "inviteToGame": "Invite to Game",
-        "chat": "Chat",
-        "reject": "Reject",
-        "accept": "Accept",
-        "cancel": "Cancel",
-        "addFriend": "Add friend"
+      "friends": {
+        "offline": "Friends offline",
+        "online": "Friends online",
+        "title": "Friends"
       },
       "guest": {
-        "title": "Connect with the community",
         "body": "To find friends, see who's online and play games, you need an account.",
         "login": "Login",
         "noAccount": "Don't have an account?",
-        "signup": "Create one"
-      }
+        "signup": "Create one",
+        "title": "Connect with the community"
+      },
+      "requests": {
+        "received": "Received",
+        "sent": "Sent",
+        "title": "Requests"
+      },
+      "searchLabel": "Search",
+      "searchPlaceholder": "Search users",
+      "title": "Social"
     }
   },
   "validation": {
-    "REQUIRED": "This field is required.",
+    "FIELD_TOO_LONG": "Too long.",
+    "FIELD_TOO_SHORT": "Too short.",
     "INVALID_EMAIL": "Enter a valid email address.",
-    "INVALID_USERNAME": "Username must be 3–30 characters and contain only letters, numbers, underscores (_), or hyphens (-).",
     "INVALID_EMAIL_OR_USERNAME": "Enter a valid email address or username.",
     "INVALID_FORMAT": "Invalid format.",
-    "USERNAME_TOO_SHORT": "Username must be at least 3 characters.",
-    "USERNAME_TOO_LONG": "Username must be no more than 30 characters.",
+    "INVALID_USERNAME": "Username must be 3–30 characters and contain only letters, numbers, underscores (_), or hyphens (-).",
     "INVALID_USERNAME_FORMAT": "Username can only contain letters, numbers, underscores (_), and hyphens (-).",
-    "FIELD_TOO_SHORT": "Too short.",
-    "FIELD_TOO_LONG": "Too long.",
+    "OUT_OF_RANGE": "Query out of range",
     "PASSWORDS_DO_NOT_MATCH": "Passwords do not match.",
-    "OUT_OF_RANGE": "Query out of range"
+    "REQUIRED": "This field is required.",
+    "USERNAME_TOO_LONG": "Username must be no more than 30 characters.",
+    "USERNAME_TOO_SHORT": "Username must be at least 3 characters."
   },
   "errors": {
-    "AUTH_EMAIL_ALREADY_EXISTS": "This email already exists",
-    "AUTH_INVALID_CREDENTIALS": "Invalid credentials",
     "AUTH_ACCOUNT_LOCKED": "Your account is temporarily locked. Try again later.",
-    "AUTH_RATE_LIMITED": "Too many attempts. Please try again later.",
-    "AUTH_NO_PENDING_RECOVER": "No password reset request was found. Please start again.",
+    "AUTH_EMAIL_ALREADY_EXISTS": "This email already exists",
     "AUTH_EMAIL_NOT_VERIFIED": "Verify your email before signing in.",
-    "AUTH_TOKEN_EXPIRED": "The verification link is invalid or expired.",
-    "AUTH_UNAUTHORIZED": "You must be logged in to view this content.",
     "AUTH_FORBIDDEN": "You do not have permission to access this resource.",
     "AUTH_INTERNAL_ERROR": "Something went wrong. Please try again.",
-    "VALIDATION_ERROR": "Validation error: please check the fields and try again.",
+    "AUTH_INVALID_CREDENTIALS": "Invalid credentials",
+    "AUTH_NO_PENDING_RECOVER": "No password reset request was found. Please start again.",
+    "AUTH_RATE_LIMITED": "Too many attempts. Please try again later.",
+    "AUTH_TOKEN_EXPIRED": "The verification link is invalid or expired.",
+    "AUTH_UNAUTHORIZED": "You must be logged in to view this content.",
     "FETCH_FAILED": "API request failed. Try again later.",
-    "generic": "Something went wrong. Please try again.",
-    "UNAUTHORIZED_ACTION": "Action not allowed.",
-    "FRIENDSHIP_REQUEST_NOT_FOUND": "Request not found or no longer available.",
     "FRIENDSHIP_ALREADY_ACCEPTED": "This request was already accepted.",
-    "FRIENDSHIP_NOT_FOUND": "Friendship not found.",
-    "USER_NOT_FOUND": "User not found.",
-    "INTERNAL_ERROR": "Something went wrong. Please try again.",
     "FRIENDSHIP_ALREADY_EXISTS": "You are already friends.",
+    "FRIENDSHIP_NOT_FOUND": "Friendship not found.",
+    "FRIENDSHIP_REQUEST_ALREADY_SENT": "A friend request has already been sent.",
+    "FRIENDSHIP_REQUEST_NOT_FOUND": "Request not found or no longer available.",
     "FRIENDSHIP_SELF_REQUEST": "You cannot add yourself.",
-    "FRIENDSHIP_REQUEST_ALREADY_SENT": "A friend request has already been sent."
+    "generic": "Something went wrong. Please try again.",
+    "INTERNAL_ERROR": "Something went wrong. Please try again.",
+    "UNAUTHORIZED_ACTION": "Action not allowed.",
+    "USER_NOT_FOUND": "User not found.",
+    "VALIDATION_ERROR": "Validation error: please check the fields and try again."
   }
 };
 export default messages;

--- a/containers/frontend/web/src/i18n/messages/en.json
+++ b/containers/frontend/web/src/i18n/messages/en.json
@@ -11,24 +11,24 @@
       "me": "My Account",
       "reset-password": "Reset Password"
     },
-    "submitButton": {
-      "pendingLabel": "Submitting..."
+    "footer": {
+      "appName": "Transcendence",
+      "copyright": "© {year} {appName}. All rights reserved",
+      "github": "GitHub",
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Service"
     },
     "localeSwitcher": {
       "ariaLabel": "Language",
+      "ca": "CA",
       "en": "EN",
-      "es": "ES",
-      "ca": "CA"
+      "es": "ES"
+    },
+    "submitButton": {
+      "pendingLabel": "Submitting..."
     },
     "textAreaField": {
       "characterCount": "{current} of {max} characters"
-    },
-    "footer": {
-      "appName": "Transcendence",
-      "privacy": "Privacy Policy",
-      "terms": "Terms of Service",
-      "github": "GitHub",
-      "copyright": "© {year} {appName}. All rights reserved"
     }
   },
   "layouts": {
@@ -39,318 +39,318 @@
   },
   "pages": {
     "home": {
-      "title": "Hello from Next in Docker 👋",
-      "subtitle": "If you can see this, routing + dev server work."
-    },
-    "notFound": {
-      "title": "Page not found",
-      "description": "The page you're looking for doesn't exist.",
-      "backToHome": "Back to Home"
+      "subtitle": "If you can see this, routing + dev server work.",
+      "title": "Hello from Next in Docker 👋"
     },
     "me": {
-      "title": "My Account",
-      "subtitle": "Access your protected account data."
+      "subtitle": "Access your protected account data.",
+      "title": "My Account"
+    },
+    "notFound": {
+      "backToHome": "Back to Home",
+      "description": "The page you're looking for doesn't exist.",
+      "title": "Page not found"
     },
     "privacy": {
-      "title": "Privacy Policy",
-      "lastUpdated": "Last updated: April 2026",
-      "intro": "At Transcendence, we value your privacy. This policy describes what data we collect, how we use it, how we store it, and what rights you have regarding your personal information.",
+      "contact": {
+        "description": "If you have any questions about this policy or wish to exercise your rights, please contact the development team through our <link>GitHub repository</link>.",
+        "title": "Contact"
+      },
       "dataCollected": {
-        "title": "Data Collected",
         "description": "When you use our platform, we may collect the following information:",
         "items": {
           "email": "Email address (used for account registration and authentication)",
-          "username": "Username (chosen by you to identify yourself in the game)",
+          "technical": "Technical data (browser type, device information, and IP address for security purposes)",
           "usage": "Usage data (game history, scores, and interaction logs)",
-          "technical": "Technical data (browser type, device information, and IP address for security purposes)"
-        }
+          "username": "Username (chosen by you to identify yourself in the game)"
+        },
+        "title": "Data Collected"
       },
       "dataUsage": {
-        "title": "How We Use Your Data",
         "description": "The data we collect is used exclusively for the following purposes:",
         "items": {
           "account": "Account management and authentication",
+          "communication": "Sending necessary communications related to your account",
           "gameplay": "Providing the game experience and social features",
-          "improvement": "Improving and optimizing the platform",
-          "communication": "Sending necessary communications related to your account"
-        }
+          "improvement": "Improving and optimizing the platform"
+        },
+        "title": "How We Use Your Data"
       },
-      "storage": {
-        "title": "Data Storage and Security",
-        "description": "Your data is stored securely on our servers. We implement industry-standard security measures including encrypted connections (HTTPS), secure password hashing, and regular security audits. We retain your data only for as long as your account is active or as needed to provide you with our services."
-      },
+      "intro": "At Transcendence, we value your privacy. This policy describes what data we collect, how we use it, how we store it, and what rights you have regarding your personal information.",
+      "lastUpdated": "Last updated: April 2026",
       "rights": {
-        "title": "Your Rights",
         "description": "As a user, you have the following rights regarding your personal data:",
         "items": {
           "access": "Right to access your personal data",
-          "rectification": "Right to correct inaccurate data",
           "deletion": "Right to request deletion of your data",
-          "portability": "Right to data portability"
-        }
+          "portability": "Right to data portability",
+          "rectification": "Right to correct inaccurate data"
+        },
+        "title": "Your Rights"
       },
-      "contact": {
-        "title": "Contact",
-        "description": "If you have any questions about this policy or wish to exercise your rights, please contact the development team through our <link>GitHub repository</link>."
-      }
+      "storage": {
+        "description": "Your data is stored securely on our servers. We implement industry-standard security measures including encrypted connections (HTTPS), secure password hashing, and regular security audits. We retain your data only for as long as your account is active or as needed to provide you with our services.",
+        "title": "Data Storage and Security"
+      },
+      "title": "Privacy Policy"
     },
     "terms": {
-      "title": "Terms of Service",
-      "lastUpdated": "Last updated: April 2026",
-      "intro": "Welcome to Transcendence. Your use of this platform is subject to the following Terms of Service, which govern the relationship between you and the development team.",
       "acceptance": {
-        "title": "Acceptance of Terms",
-        "description": "By creating an account or using our services, you agree to these conditions in their entirety. If you do not agree with any part of these Terms, you must refrain from using the platform."
-      },
-      "registration": {
-        "title": "Account Registration",
-        "description": "You are responsible for maintaining the confidentiality of your credentials and for all activities that occur under your account.",
-        "items": {
-          "security": "You must notify us immediately of any unauthorized use of your account.",
-          "accuracy": "You agree to provide accurate and complete information during registration."
-        }
+        "description": "By creating an account or using our services, you agree to these conditions in their entirety. If you do not agree with any part of these Terms, you must refrain from using the platform.",
+        "title": "Acceptance of Terms"
       },
       "conduct": {
-        "title": "User Conduct",
         "description": "To maintain a fair, respectful, and fun environment, you agree not to:",
         "items": {
           "cheating": "Use cheats, automation software (bots), or hacks to gain an advantage.",
-          "harassment": "Harass, abuse, or engage in behavior that harms the community or other players.",
-          "disruption": "Attempt to disrupt the integrity or security of our servers."
-        }
-      },
-      "ip": {
-        "title": "Intellectual Property",
-        "description": "All content, including game code, graphics, and trademarks, is the property of Transcendence. We grant you a limited, non-transferable license for personal, non-commercial use."
-      },
-      "disclaimer": {
-        "title": "Disclaimers",
-        "description": "Transcendence is an educational and community-driven project. Consequently, the service is provided as is and as available. We do not warrant that the service will be uninterrupted, timely, secure, or error-free."
-      },
-      "termination": {
-        "title": "Termination",
-        "description": "We reserve the right to suspend or terminate your account at our sole discretion, without notice, for conduct that we believe violates these Terms or is harmful to other users, us, or third parties."
-      },
-      "law": {
-        "title": "Governing Law",
-        "description": "These Terms shall be governed by and construed in accordance with the laws applicable to digital services within the scope of this project's jurisdiction."
+          "disruption": "Attempt to disrupt the integrity or security of our servers.",
+          "harassment": "Harass, abuse, or engage in behavior that harms the community or other players."
+        },
+        "title": "User Conduct"
       },
       "contact": {
-        "title": "Contact Us",
-        "description": "If you have any questions or wish to exercise your rights, please contact the development team by opening an issue on our <link>GitHub repository</link>."
-      }
+        "description": "If you have any questions or wish to exercise your rights, please contact the development team by opening an issue on our <link>GitHub repository</link>.",
+        "title": "Contact Us"
+      },
+      "disclaimer": {
+        "description": "Transcendence is an educational and community-driven project. Consequently, the service is provided as is and as available. We do not warrant that the service will be uninterrupted, timely, secure, or error-free.",
+        "title": "Disclaimers"
+      },
+      "intro": "Welcome to Transcendence. Your use of this platform is subject to the following Terms of Service, which govern the relationship between you and the development team.",
+      "ip": {
+        "description": "All content, including game code, graphics, and trademarks, is the property of Transcendence. We grant you a limited, non-transferable license for personal, non-commercial use.",
+        "title": "Intellectual Property"
+      },
+      "lastUpdated": "Last updated: April 2026",
+      "law": {
+        "description": "These Terms shall be governed by and construed in accordance with the laws applicable to digital services within the scope of this project's jurisdiction.",
+        "title": "Governing Law"
+      },
+      "registration": {
+        "description": "You are responsible for maintaining the confidentiality of your credentials and for all activities that occur under your account.",
+        "items": {
+          "accuracy": "You agree to provide accurate and complete information during registration.",
+          "security": "You must notify us immediately of any unauthorized use of your account."
+        },
+        "title": "Account Registration"
+      },
+      "termination": {
+        "description": "We reserve the right to suspend or terminate your account at our sole discretion, without notice, for conduct that we believe violates these Terms or is harmful to other users, us, or third parties.",
+        "title": "Termination"
+      },
+      "title": "Terms of Service"
     }
   },
   "features": {
     "auth": {
+      "actions": {
+        "continueWithGoogle": "Continue with Google",
+        "login": "Log in",
+        "logoutAriaLabel": "Log out",
+        "resendEmail": "Resend email",
+        "sendEmail": "Send email",
+        "signup": "Create account"
+      },
+      "changePassword": {
+        "description": "Enter your current password and choose a new one.",
+        "submit": "Save changes",
+        "success": "Password updated successfully.",
+        "title": "Change password"
+      },
       "fields": {
-        "identifier": {
-          "label": "Email or username",
-          "placeholder": "name@example.com or username",
-          "description": "Use the email address or username you signed up with."
-        },
-        "email": {
-          "label": "Email",
-          "placeholder": "name@example.com"
-        },
-        "username": {
-          "label": "Username",
-          "placeholder": "your_username"
-        },
-        "password": {
-          "label": "Password",
-          "placeholder": "Enter your password",
-          "description": "Min 8 characters long."
+        "confirmPassword": {
+          "label": "Confirm password",
+          "placeholder": "Re-enter your password"
         },
         "currentPassword": {
           "label": "Current password",
           "placeholder": "Enter your current password"
         },
-        "newPassword": {
-          "label": "New password",
-          "placeholder": "Enter your new password",
-          "description": "Min 8 characters long."
+        "email": {
+          "label": "Email",
+          "placeholder": "name@example.com"
         },
-        "confirmPassword": {
-          "label": "Confirm password",
-          "placeholder": "Re-enter your password"
+        "identifier": {
+          "description": "Use the email address or username you signed up with.",
+          "label": "Email or username",
+          "placeholder": "name@example.com or username"
+        },
+        "newPassword": {
+          "description": "Min 8 characters long.",
+          "label": "New password",
+          "placeholder": "Enter your new password"
+        },
+        "password": {
+          "description": "Min 8 characters long.",
+          "label": "Password",
+          "placeholder": "Enter your password"
+        },
+        "username": {
+          "label": "Username",
+          "placeholder": "your_username"
         }
       },
-      "actions": {
-        "login": "Log in",
-        "signup": "Create account",
-        "continueWithGoogle": "Continue with Google",
-        "sendEmail": "Send email",
-        "resendEmail": "Resend email",
-        "logoutAriaLabel": "Log out"
-      },
       "login": {
-        "title": "Log in",
-        "submit": "Log in",
         "forgotPassword": "Forgot password?",
+        "goToSignup": "Create one",
         "noAccount": "Don’t have an account?",
-        "goToSignup": "Create one"
-      },
-      "signup": {
-        "title": "Create account",
-        "privacy": {
-          "label": "I have read and agree to the <link>Privacy Policy</link>",
-          "error": "You must accept the Privacy Policy to continue."
-        },
-        "haveAccount": "Already have an account?",
-        "goToLogin": "Log in"
-      },
-      "verification": {
-        "title": "Check your email",
-        "sent": "We've sent you an email to confirm your account.",
-        "checkInbox": "Check your inbox and follow the instructions to activate your account.",
-        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, you can resend it.",
-        "verifying": "Verifying your email...",
-        "verified": "Email verified. Redirecting to your profile...",
-        "missingToken": "Verification token is missing.",
-        "invalidOrExpired": "Verification link is invalid or expired.",
-        "resending": "Sending...",
-        "isConfirmed": "Already confirmed?",
-        "backToLogin": "Log In",
-        "recoverTitle": "Recover account",
-        "resendTitle": "Resend verification email",
-        "resendDescription": "Enter the email address you used to create your account."
-      },
-      "recover": {
-        "title": "Check your email",
-        "sent": "We've sent password reset instructions to the address you entered.",
-        "checkInbox": "Check your inbox and follow the instructions to set a new password.",
-        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, try again later.",
-        "rememberedPassword": "Remembered your password?",
-        "backToLogin": "Back to login"
-      },
-      "reset": {
-        "title": "Reset password",
-        "description": "Enter your new password.",
-        "submit": "Save new password",
-        "success": "Password updated successfully.",
-        "backToLogin": "Back to login"
-      },
-      "changePassword": {
-        "title": "Change password",
-        "description": "Enter your current password and choose a new one.",
-        "submit": "Save changes",
-        "success": "Password updated successfully."
+        "submit": "Log in",
+        "title": "Log in"
       },
       "messages": {
         "or": "OR",
         "success": "Email sent. Wait before trying again."
+      },
+      "recover": {
+        "backToLogin": "Back to login",
+        "checkInbox": "Check your inbox and follow the instructions to set a new password.",
+        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, try again later.",
+        "rememberedPassword": "Remembered your password?",
+        "sent": "We've sent password reset instructions to the address you entered.",
+        "title": "Check your email"
+      },
+      "reset": {
+        "backToLogin": "Back to login",
+        "description": "Enter your new password.",
+        "submit": "Save new password",
+        "success": "Password updated successfully.",
+        "title": "Reset password"
+      },
+      "signup": {
+        "goToLogin": "Log in",
+        "haveAccount": "Already have an account?",
+        "privacy": {
+          "error": "You must accept the Privacy Policy to continue.",
+          "label": "I have read and agree to the <link>Privacy Policy</link>"
+        },
+        "title": "Create account"
+      },
+      "verification": {
+        "backToLogin": "Log In",
+        "checkInbox": "Check your inbox and follow the instructions to activate your account.",
+        "checkSpam": "If you can't find it, check your spam folder. If it's not there either, you can resend it.",
+        "invalidOrExpired": "Verification link is invalid or expired.",
+        "isConfirmed": "Already confirmed?",
+        "missingToken": "Verification token is missing.",
+        "recoverTitle": "Recover account",
+        "resendDescription": "Enter the email address you used to create your account.",
+        "resending": "Sending...",
+        "resendTitle": "Resend verification email",
+        "sent": "We've sent you an email to confirm your account.",
+        "title": "Check your email",
+        "verified": "Email verified. Redirecting to your profile...",
+        "verifying": "Verifying your email..."
       }
     },
-    "navigation": {
-      "home": "Home",
-      "createAccount": "Create account",
-      "login": "Log in",
-      "menu": "Menu",
-      "mainAriaLabel": "Main navigation",
-      "ui": "UI",
-      "game": "Game",
-      "profile": "Profile",
-      "logout": "Logout",
-      "settings": "Settings"
-    },
     "chat": {
+      "hideChat": "Hide Chat",
       "messageAriaLabel": "Message",
-      "showChat": "Show Chat",
-      "hideChat": "Hide Chat"
+      "showChat": "Show Chat"
     },
     "game": {
-      "resetPlan": "Reset plan",
       "endTurn": "End turn",
-      "healthLabel": "HP"
+      "healthLabel": "HP",
+      "resetPlan": "Reset plan"
     },
-    "settings": {
-      "theme": "Theme",
-      "language": "Language",
-      "dark": "Dark",
-      "light": "Light"
+    "navigation": {
+      "createAccount": "Create account",
+      "game": "Game",
+      "home": "Home",
+      "login": "Log in",
+      "logout": "Logout",
+      "mainAriaLabel": "Main navigation",
+      "menu": "Menu",
+      "profile": "Profile",
+      "settings": "Settings",
+      "ui": "UI"
     },
     "profile": {
-      "fail": "Could not load your profile.",
-      "userId": "User ID",
-      "username": "Username",
       "bio": "Bio",
-      "provider": "Provider"
+      "fail": "Could not load your profile.",
+      "provider": "Provider",
+      "userId": "User ID",
+      "username": "Username"
+    },
+    "settings": {
+      "dark": "Dark",
+      "language": "Language",
+      "light": "Light",
+      "theme": "Theme"
     },
     "social": {
-      "title": "Social",
-      "searchPlaceholder": "Search users",
-      "searchLabel": "Search",
-      "friends": {
-        "title": "Friends",
-        "online": "Friends online",
-        "offline": "Friends offline"
-      },
-      "requests": {
-        "title": "Requests",
-        "received": "Received",
-        "sent": "Sent"
+      "actions": {
+        "accept": "Accept",
+        "addFriend": "Add friend",
+        "cancel": "Cancel",
+        "chat": "Chat",
+        "inviteToGame": "Invite to Game",
+        "reject": "Reject"
       },
       "emptyStates": {
-        "online": "No friends online right now",
         "offline": "No friends offline",
-        "request": "No pending friend requests",
+        "online": "No friends online right now",
         "pending": "No sent requests pending",
+        "request": "No pending friend requests",
         "search": "No users found"
       },
-      "actions": {
-        "inviteToGame": "Invite to Game",
-        "chat": "Chat",
-        "reject": "Reject",
-        "accept": "Accept",
-        "cancel": "Cancel",
-        "addFriend": "Add friend"
+      "friends": {
+        "offline": "Friends offline",
+        "online": "Friends online",
+        "title": "Friends"
       },
       "guest": {
-        "title": "Connect with the community",
         "body": "To find friends, see who's online and play games, you need an account.",
         "login": "Login",
         "noAccount": "Don't have an account?",
-        "signup": "Create one"
-      }
+        "signup": "Create one",
+        "title": "Connect with the community"
+      },
+      "requests": {
+        "received": "Received",
+        "sent": "Sent",
+        "title": "Requests"
+      },
+      "searchLabel": "Search",
+      "searchPlaceholder": "Search users",
+      "title": "Social"
     }
   },
   "validation": {
-    "REQUIRED": "This field is required.",
+    "FIELD_TOO_LONG": "Too long.",
+    "FIELD_TOO_SHORT": "Too short.",
     "INVALID_EMAIL": "Enter a valid email address.",
-    "INVALID_USERNAME": "Username must be 3–30 characters and contain only letters, numbers, underscores (_), or hyphens (-).",
     "INVALID_EMAIL_OR_USERNAME": "Enter a valid email address or username.",
     "INVALID_FORMAT": "Invalid format.",
-    "USERNAME_TOO_SHORT": "Username must be at least 3 characters.",
-    "USERNAME_TOO_LONG": "Username must be no more than 30 characters.",
+    "INVALID_USERNAME": "Username must be 3–30 characters and contain only letters, numbers, underscores (_), or hyphens (-).",
     "INVALID_USERNAME_FORMAT": "Username can only contain letters, numbers, underscores (_), and hyphens (-).",
-    "FIELD_TOO_SHORT": "Too short.",
-    "FIELD_TOO_LONG": "Too long.",
+    "OUT_OF_RANGE": "Query out of range",
     "PASSWORDS_DO_NOT_MATCH": "Passwords do not match.",
-    "OUT_OF_RANGE": "Query out of range"
+    "REQUIRED": "This field is required.",
+    "USERNAME_TOO_LONG": "Username must be no more than 30 characters.",
+    "USERNAME_TOO_SHORT": "Username must be at least 3 characters."
   },
   "errors": {
-    "AUTH_EMAIL_ALREADY_EXISTS": "This email already exists",
-    "AUTH_INVALID_CREDENTIALS": "Invalid credentials",
     "AUTH_ACCOUNT_LOCKED": "Your account is temporarily locked. Try again later.",
-    "AUTH_RATE_LIMITED": "Too many attempts. Please try again later.",
-    "AUTH_NO_PENDING_RECOVER": "No password reset request was found. Please start again.",
+    "AUTH_EMAIL_ALREADY_EXISTS": "This email already exists",
     "AUTH_EMAIL_NOT_VERIFIED": "Verify your email before signing in.",
-    "AUTH_TOKEN_EXPIRED": "The verification link is invalid or expired.",
-    "AUTH_UNAUTHORIZED": "You must be logged in to view this content.",
     "AUTH_FORBIDDEN": "You do not have permission to access this resource.",
     "AUTH_INTERNAL_ERROR": "Something went wrong. Please try again.",
-    "VALIDATION_ERROR": "Validation error: please check the fields and try again.",
+    "AUTH_INVALID_CREDENTIALS": "Invalid credentials",
+    "AUTH_NO_PENDING_RECOVER": "No password reset request was found. Please start again.",
+    "AUTH_RATE_LIMITED": "Too many attempts. Please try again later.",
+    "AUTH_TOKEN_EXPIRED": "The verification link is invalid or expired.",
+    "AUTH_UNAUTHORIZED": "You must be logged in to view this content.",
     "FETCH_FAILED": "API request failed. Try again later.",
-    "generic": "Something went wrong. Please try again.",
-    "UNAUTHORIZED_ACTION": "Action not allowed.",
-    "FRIENDSHIP_REQUEST_NOT_FOUND": "Request not found or no longer available.",
     "FRIENDSHIP_ALREADY_ACCEPTED": "This request was already accepted.",
-    "FRIENDSHIP_NOT_FOUND": "Friendship not found.",
-    "USER_NOT_FOUND": "User not found.",
-    "INTERNAL_ERROR": "Something went wrong. Please try again.",
     "FRIENDSHIP_ALREADY_EXISTS": "You are already friends.",
+    "FRIENDSHIP_NOT_FOUND": "Friendship not found.",
+    "FRIENDSHIP_REQUEST_ALREADY_SENT": "A friend request has already been sent.",
+    "FRIENDSHIP_REQUEST_NOT_FOUND": "Request not found or no longer available.",
     "FRIENDSHIP_SELF_REQUEST": "You cannot add yourself.",
-    "FRIENDSHIP_REQUEST_ALREADY_SENT": "A friend request has already been sent."
+    "generic": "Something went wrong. Please try again.",
+    "INTERNAL_ERROR": "Something went wrong. Please try again.",
+    "UNAUTHORIZED_ACTION": "Action not allowed.",
+    "USER_NOT_FOUND": "User not found.",
+    "VALIDATION_ERROR": "Validation error: please check the fields and try again."
   }
 }

--- a/containers/frontend/web/src/i18n/messages/es.json
+++ b/containers/frontend/web/src/i18n/messages/es.json
@@ -11,24 +11,24 @@
       "me": "Mi Cuenta",
       "reset-password": "Restablecer Contraseña"
     },
+    "footer": {
+      "appName": "Transcendence",
+      "copyright": "© {year} {appName}. Todos los derechos reservados",
+      "github": "GitHub",
+      "privacy": "Política de Privacidad",
+      "terms": "Términos de Servicio"
+    },
     "localeSwitcher": {
       "ariaLabel": "Idioma",
+      "ca": "CA",
       "en": "EN",
-      "es": "ES",
-      "ca": "CA"
-    },
-    "textAreaField": {
-      "characterCount": "{current} de {max} caracteres"
+      "es": "ES"
     },
     "submitButton": {
       "pendingLabel": "Enviando..."
     },
-    "footer": {
-      "appName": "Transcendence",
-      "privacy": "Política de Privacidad",
-      "terms": "Términos de Servicio",
-      "github": "GitHub",
-      "copyright": "© {year} {appName}. Todos los derechos reservados"
+    "textAreaField": {
+      "characterCount": "{current} de {max} caracteres"
     }
   },
   "layouts": {
@@ -39,317 +39,317 @@
   },
   "pages": {
     "home": {
-      "title": "Hola desde Next en Docker 👋",
-      "subtitle": "Si ves esto, el routing y el servidor de desarrollo funcionan."
-    },
-    "notFound": {
-      "title": "Página no encontrada",
-      "description": "La página que buscas no existe.",
-      "backToHome": "Volver al inicio"
+      "subtitle": "Si ves esto, el routing y el servidor de desarrollo funcionan.",
+      "title": "Hola desde Next en Docker 👋"
     },
     "me": {
-      "title": "Mi Cuenta",
-      "subtitle": "Accede a los datos protegidos de tu cuenta."
+      "subtitle": "Accede a los datos protegidos de tu cuenta.",
+      "title": "Mi Cuenta"
+    },
+    "notFound": {
+      "backToHome": "Volver al inicio",
+      "description": "La página que buscas no existe.",
+      "title": "Página no encontrada"
     },
     "privacy": {
-      "title": "Política de Privacidad",
-      "lastUpdated": "Última actualización: Abril 2026",
-      "intro": "En Transcendence, valoramos tu privacidad. Esta política describe qué datos recopilamos, cómo los usamos, cómo los almacenamos y qué derechos tienes sobre tu información personal.",
+      "contact": {
+        "description": "Si tienes alguna pregunta sobre esta política o deseas ejercer tus derechos, por favor contacta con el equipo abriendo una incidencia en nuestro <link>repositorio de GitHub</link>.",
+        "title": "Contacto"
+      },
       "dataCollected": {
-        "title": "Datos Recopilados",
         "description": "Cuando usas nuestra plataforma, podemos recopilar la siguiente información:",
         "items": {
           "email": "Dirección de correo electrónico (usada para el registro y la autenticación)",
-          "username": "Nombre de usuario (elegido por ti para identificarte en el juego)",
+          "technical": "Datos técnicos (tipo de navegador, información del dispositivo y dirección IP con fines de seguridad)",
           "usage": "Datos de uso (historial de partidas, puntuaciones y registros de interacción)",
-          "technical": "Datos técnicos (tipo de navegador, información del dispositivo y dirección IP con fines de seguridad)"
-        }
+          "username": "Nombre de usuario (elegido por ti para identificarte en el juego)"
+        },
+        "title": "Datos Recopilados"
       },
       "dataUsage": {
-        "title": "Cómo Usamos tus Datos",
         "description": "Los datos que recopilamos se utilizan exclusivamente para los siguientes fines:",
         "items": {
           "account": "Gestión de cuentas y autenticación",
+          "communication": "Enviar comunicaciones necesarias relacionadas con tu cuenta",
           "gameplay": "Proporcionar la experiencia de juego y funciones sociales",
-          "improvement": "Mejorar y optimizar la plataforma",
-          "communication": "Enviar comunicaciones necesarias relacionadas con tu cuenta"
-        }
+          "improvement": "Mejorar y optimizar la plataforma"
+        },
+        "title": "Cómo Usamos tus Datos"
       },
-      "storage": {
-        "title": "Almacenamiento y Seguridad de Datos",
-        "description": "Tus datos se almacenan de forma segura en nuestros servidores. Implementamos medidas de seguridad estándar de la industria, incluyendo conexiones cifradas (HTTPS), hash seguro de contraseñas y auditorías de seguridad regulares. Conservamos tus datos solo mientras tu cuenta esté activa o según sea necesario para proporcionarte nuestros servicios."
-      },
+      "intro": "En Transcendence, valoramos tu privacidad. Esta política describe qué datos recopilamos, cómo los usamos, cómo los almacenamos y qué derechos tienes sobre tu información personal.",
+      "lastUpdated": "Última actualización: Abril 2026",
       "rights": {
-        "title": "Tus Derechos",
         "description": "Como usuario, tienes los siguientes derechos sobre tus datos personales:",
         "items": {
           "access": "Derecho a acceder a tus datos personales",
-          "rectification": "Derecho a corregir datos inexactos",
           "deletion": "Derecho a solicitar la eliminación de tus datos",
-          "portability": "Derecho a la portabilidad de datos"
-        }
+          "portability": "Derecho a la portabilidad de datos",
+          "rectification": "Derecho a corregir datos inexactos"
+        },
+        "title": "Tus Derechos"
       },
-      "contact": {
-        "title": "Contacto",
-        "description": "Si tienes alguna pregunta sobre esta política o deseas ejercer tus derechos, por favor contacta con el equipo abriendo una incidencia en nuestro <link>repositorio de GitHub</link>."
-      }
+      "storage": {
+        "description": "Tus datos se almacenan de forma segura en nuestros servidores. Implementamos medidas de seguridad estándar de la industria, incluyendo conexiones cifradas (HTTPS), hash seguro de contraseñas y auditorías de seguridad regulares. Conservamos tus datos solo mientras tu cuenta esté activa o según sea necesario para proporcionarte nuestros servicios.",
+        "title": "Almacenamiento y Seguridad de Datos"
+      },
+      "title": "Política de Privacidad"
     },
     "terms": {
-      "title": "Términos de Servicio",
-      "lastUpdated": "Última actualización: Abril 2026",
-      "intro": "Bienvenido a Transcendence. El uso de esta plataforma está sujeto a los siguientes Términos de Servicio, que rigen la relación entre tú y el equipo de desarrollo.",
       "acceptance": {
-        "title": "Aceptación de los Términos",
-        "description": "Al crear una cuenta o utilizar nuestros servicios, aceptas estas condiciones en su totalidad. Si no estás de acuerdo con alguna parte de estos Términos, debes abstenerte de utilizar la plataforma."
-      },
-      "registration": {
-        "title": "Registro de Cuenta",
-        "description": "Eres responsable de mantener la confidencialidad de tus credenciales y de todas las actividades que ocurran bajo tu cuenta.",
-        "items": {
-          "security": "Debes notificarnos inmediatamente cualquier uso no autorizado de tu cuenta.",
-          "accuracy": "Aceptas proporcionar información precisa y completa durante el registro."
-        }
+        "description": "Al crear una cuenta o utilizar nuestros servicios, aceptas estas condiciones en su totalidad. Si no estás de acuerdo con alguna parte de estos Términos, debes abstenerte de utilizar la plataforma.",
+        "title": "Aceptación de los Términos"
       },
       "conduct": {
-        "title": "Conducta del Usuario",
         "description": "Para mantener un entorno justo, respetuoso y divertido, te comprometes a no:",
         "items": {
           "cheating": "Utilizar trampas, software de automatización (bots) o hacks para obtener ventaja.",
-          "harassment": "Acosar, abusar o participar en conductas que dañen a la comunidad o a otros jugadores.",
-          "disruption": "Intentar interrumpir la integridad o seguridad de nuestros servidores."
-        }
-      },
-      "ip": {
-        "title": "Propiedad Intelectual",
-        "description": "Todo el contenido, incluyendo el código del juego, gráficos y marcas registradas, es propiedad de Transcendence. Otorgamos una licencia limitada y no transferible para uso personal y no comercial."
-      },
-      "disclaimer": {
-        "title": "Exención de responsabilidad",
-        "description": "Transcendence es un proyecto educativo y comunitario. En consecuencia, el servicio se proporciona tal cual y según disponibilidad. No garantizamos que el servicio sea ininterrumpido, puntual, seguro o libre de errores."
-      },
-      "termination": {
-        "title": "Cancelación",
-        "description": "Nos reservamos el derecho de suspender o cerrar tu cuenta a nuestra discreción, sin previo aviso, por conductas que consideremos que violan estos Términos o que resulten perjudiciales para otros usuarios o el proyecto."
-      },
-      "law": {
-        "title": "Ley Aplicable",
-        "description": "Estos Términos se rigen e interpretan de acuerdo con las leyes aplicables a los servicios digitales dentro del ámbito de jurisdicción de este proyecto."
+          "disruption": "Intentar interrumpir la integridad o seguridad de nuestros servidores.",
+          "harassment": "Acosar, abusar o participar en conductas que dañen a la comunidad o a otros jugadores."
+        },
+        "title": "Conducta del Usuario"
       },
       "contact": {
-        "title": "Contacto",
-        "description": "Si tienes preguntas o deseas ejercer cualquier derecho relacionado con estos Términos, por favor contacta con el equipo abriendo una incidencia en nuestro <link>repositorio de GitHub</link>."
-      }
+        "description": "Si tienes preguntas o deseas ejercer cualquier derecho relacionado con estos Términos, por favor contacta con el equipo abriendo una incidencia en nuestro <link>repositorio de GitHub</link>.",
+        "title": "Contacto"
+      },
+      "disclaimer": {
+        "description": "Transcendence es un proyecto educativo y comunitario. En consecuencia, el servicio se proporciona tal cual y según disponibilidad. No garantizamos que el servicio sea ininterrumpido, puntual, seguro o libre de errores.",
+        "title": "Exención de responsabilidad"
+      },
+      "intro": "Bienvenido a Transcendence. El uso de esta plataforma está sujeto a los siguientes Términos de Servicio, que rigen la relación entre tú y el equipo de desarrollo.",
+      "ip": {
+        "description": "Todo el contenido, incluyendo el código del juego, gráficos y marcas registradas, es propiedad de Transcendence. Otorgamos una licencia limitada y no transferible para uso personal y no comercial.",
+        "title": "Propiedad Intelectual"
+      },
+      "lastUpdated": "Última actualización: Abril 2026",
+      "law": {
+        "description": "Estos Términos se rigen e interpretan de acuerdo con las leyes aplicables a los servicios digitales dentro del ámbito de jurisdicción de este proyecto.",
+        "title": "Ley Aplicable"
+      },
+      "registration": {
+        "description": "Eres responsable de mantener la confidencialidad de tus credenciales y de todas las actividades que ocurran bajo tu cuenta.",
+        "items": {
+          "accuracy": "Aceptas proporcionar información precisa y completa durante el registro.",
+          "security": "Debes notificarnos inmediatamente cualquier uso no autorizado de tu cuenta."
+        },
+        "title": "Registro de Cuenta"
+      },
+      "termination": {
+        "description": "Nos reservamos el derecho de suspender o cerrar tu cuenta a nuestra discreción, sin previo aviso, por conductas que consideremos que violan estos Términos o que resulten perjudiciales para otros usuarios o el proyecto.",
+        "title": "Cancelación"
+      },
+      "title": "Términos de Servicio"
     }
   },
   "features": {
     "auth": {
+      "actions": {
+        "continueWithGoogle": "Continuar con Google",
+        "login": "Iniciar sesión",
+        "logoutAriaLabel": "Cerrar sesión",
+        "resendEmail": "Reenviar correo",
+        "sendEmail": "Enviar correo electrónico",
+        "signup": "Crear cuenta"
+      },
+      "changePassword": {
+        "description": "Introduce tu contraseña actual y elige una nueva.",
+        "submit": "Guardar cambios",
+        "success": "La contraseña se actualizó correctamente.",
+        "title": "Cambiar contraseña"
+      },
       "fields": {
-        "identifier": {
-          "label": "Correo o nombre de usuario",
-          "placeholder": "nombre@ejemplo.com o usuario",
-          "description": "Usa el correo o el nombre de usuario con el que te registraste."
-        },
-        "email": {
-          "label": "Correo electrónico",
-          "placeholder": "nombre@ejemplo.com"
-        },
-        "username": {
-          "label": "Nombre de usuario",
-          "placeholder": "tu_usuario"
-        },
-        "password": {
-          "label": "Contraseña",
-          "placeholder": "Introduce tu contraseña",
-          "description": "Mínimo 8 caracteres."
+        "confirmPassword": {
+          "label": "Confirmar contraseña",
+          "placeholder": "Vuelve a introducir tu contraseña"
         },
         "currentPassword": {
           "label": "Contraseña actual",
           "placeholder": "Introduce tu contraseña actual"
         },
-        "newPassword": {
-          "label": "Nueva contraseña",
-          "placeholder": "Introduce tu nueva contraseña",
-          "description": "Mínimo 8 caracteres."
+        "email": {
+          "label": "Correo electrónico",
+          "placeholder": "nombre@ejemplo.com"
         },
-        "confirmPassword": {
-          "label": "Confirmar contraseña",
-          "placeholder": "Vuelve a introducir tu contraseña"
+        "identifier": {
+          "description": "Usa el correo o el nombre de usuario con el que te registraste.",
+          "label": "Correo o nombre de usuario",
+          "placeholder": "nombre@ejemplo.com o usuario"
+        },
+        "newPassword": {
+          "description": "Mínimo 8 caracteres.",
+          "label": "Nueva contraseña",
+          "placeholder": "Introduce tu nueva contraseña"
+        },
+        "password": {
+          "description": "Mínimo 8 caracteres.",
+          "label": "Contraseña",
+          "placeholder": "Introduce tu contraseña"
+        },
+        "username": {
+          "label": "Nombre de usuario",
+          "placeholder": "tu_usuario"
         }
       },
-      "actions": {
-        "login": "Iniciar sesión",
-        "signup": "Crear cuenta",
-        "continueWithGoogle": "Continuar con Google",
-        "sendEmail": "Enviar correo electrónico",
-        "resendEmail": "Reenviar correo",
-        "logoutAriaLabel": "Cerrar sesión"
-      },
       "login": {
-        "title": "Iniciar sesión",
-        "submit": "Iniciar sesión",
         "forgotPassword": "¿Has olvidado la contraseña?",
+        "goToSignup": "Crear una",
         "noAccount": "¿No tienes cuenta?",
-        "goToSignup": "Crear una"
-      },
-      "signup": {
-        "title": "Crear cuenta",
-        "privacy": {
-          "label": "He leído y acepto la <link>Política de Privacidad</link>",
-          "error": "Debes aceptar la Política de Privacidad para continuar."
-        },
-        "haveAccount": "¿Ya tienes cuenta?",
-        "goToLogin": "Iniciar sesión"
-      },
-      "verification": {
-        "title": "Verifica tu correo electrónico",
-        "sent": "Te hemos enviado un correo para confirmar tu cuenta.",
-        "checkInbox": "Revisa tu bandeja de entrada y sigue las instrucciones para activar tu cuenta.",
-        "checkSpam": "Si no lo encuentras, revisa la carpeta de correo no deseado. Si tampoco está ahí, puedes volver a enviarlo.",
-        "verifying": "Verificando tu correo...",
-        "verified": "Correo verificado. Redirigiendo a tu perfil...",
-        "missingToken": "Falta el token de verificación.",
-        "invalidOrExpired": "El enlace de verificación no es válido o ha caducado.",
-        "resending": "Enviando...",
-        "isConfirmed": "¿Ya confirmaste?",
-        "backToLogin": "Iniciar sesión",
-        "recoverTitle": "Recuperar cuenta",
-        "resendTitle": "Reenviar correo de verificación",
-        "resendDescription": "Introduce el correo electrónico que usaste para crear tu cuenta."
-      },
-      "recover": {
-        "title": "Revisa tu correo",
-        "sent": "Te hemos enviado instrucciones para restablecer la contraseña al correo que introdujiste.",
-        "checkInbox": "Revisa tu bandeja de entrada y sigue las instrucciones para crear una nueva contraseña.",
-        "checkSpam": "Si no lo encuentras, revisa la carpeta de correo no deseado. Si tampoco está ahí, inténtalo de nuevo más tarde.",
-        "rememberedPassword": "¿Has recordado tu contraseña?",
-        "backToLogin": "Volver al inicio de sesión"
-      },
-      "changePassword": {
-        "title": "Cambiar contraseña",
-        "description": "Introduce tu contraseña actual y elige una nueva.",
-        "submit": "Guardar cambios",
-        "success": "La contraseña se actualizó correctamente."
-      },
-      "reset": {
-        "title": "Restablecer contraseña",
-        "description": "Introduce tu nueva contraseña.",
-        "submit": "Guardar nueva contraseña",
-        "success": "La contraseña se actualizó correctamente.",
-        "backToLogin": "Volver a iniciar sesión"
+        "submit": "Iniciar sesión",
+        "title": "Iniciar sesión"
       },
       "messages": {
         "or": "O",
         "success": "Correo enviado. Espera para volver a intentarlo."
+      },
+      "recover": {
+        "backToLogin": "Volver al inicio de sesión",
+        "checkInbox": "Revisa tu bandeja de entrada y sigue las instrucciones para crear una nueva contraseña.",
+        "checkSpam": "Si no lo encuentras, revisa la carpeta de correo no deseado. Si tampoco está ahí, inténtalo de nuevo más tarde.",
+        "rememberedPassword": "¿Has recordado tu contraseña?",
+        "sent": "Te hemos enviado instrucciones para restablecer la contraseña al correo que introdujiste.",
+        "title": "Revisa tu correo"
+      },
+      "reset": {
+        "backToLogin": "Volver a iniciar sesión",
+        "description": "Introduce tu nueva contraseña.",
+        "submit": "Guardar nueva contraseña",
+        "success": "La contraseña se actualizó correctamente.",
+        "title": "Restablecer contraseña"
+      },
+      "signup": {
+        "goToLogin": "Iniciar sesión",
+        "haveAccount": "¿Ya tienes cuenta?",
+        "privacy": {
+          "error": "Debes aceptar la Política de Privacidad para continuar.",
+          "label": "He leído y acepto la <link>Política de Privacidad</link>"
+        },
+        "title": "Crear cuenta"
+      },
+      "verification": {
+        "backToLogin": "Iniciar sesión",
+        "checkInbox": "Revisa tu bandeja de entrada y sigue las instrucciones para activar tu cuenta.",
+        "checkSpam": "Si no lo encuentras, revisa la carpeta de correo no deseado. Si tampoco está ahí, puedes volver a enviarlo.",
+        "invalidOrExpired": "El enlace de verificación no es válido o ha caducado.",
+        "isConfirmed": "¿Ya confirmaste?",
+        "missingToken": "Falta el token de verificación.",
+        "recoverTitle": "Recuperar cuenta",
+        "resendDescription": "Introduce el correo electrónico que usaste para crear tu cuenta.",
+        "resending": "Enviando...",
+        "resendTitle": "Reenviar correo de verificación",
+        "sent": "Te hemos enviado un correo para confirmar tu cuenta.",
+        "title": "Verifica tu correo electrónico",
+        "verified": "Correo verificado. Redirigiendo a tu perfil...",
+        "verifying": "Verificando tu correo..."
       }
     },
-    "navigation": {
-      "home": "Inicio",
-      "createAccount": "Crear cuenta",
-      "login": "Iniciar sesión",
-      "menu": "Menú",
-      "mainAriaLabel": "Navegación principal",
-      "ui": "UI",
-      "game": "Juego",
-      "profile": "Perfil",
-      "logout": "Cerrar sesión",
-      "settings": "Configuración"
-    },
     "chat": {
+      "hideChat": "Ocultar chat",
       "messageAriaLabel": "Mensaje",
-      "showChat": "Mostrar chat",
-      "hideChat": "Ocultar chat"
+      "showChat": "Mostrar chat"
     },
     "game": {
-      "resetPlan": "Reiniciar plan",
       "endTurn": "Terminar turno",
-      "healthLabel": "HP"
+      "healthLabel": "HP",
+      "resetPlan": "Reiniciar plan"
     },
-    "settings": {
-      "theme": "Tema",
-      "language": "Idioma",
-      "dark": "Oscuro",
-      "light": "Claro"
+    "navigation": {
+      "createAccount": "Crear cuenta",
+      "game": "Juego",
+      "home": "Inicio",
+      "login": "Iniciar sesión",
+      "logout": "Cerrar sesión",
+      "mainAriaLabel": "Navegación principal",
+      "menu": "Menú",
+      "profile": "Perfil",
+      "settings": "Configuración",
+      "ui": "UI"
     },
     "profile": {
-      "fail": "No se pudo cargar tu perfil.",
-      "userId": "ID de usuario",
-      "username": "Nombre de usuario",
       "bio": "Biografía",
-      "provider": "Proveedor"
+      "fail": "No se pudo cargar tu perfil.",
+      "provider": "Proveedor",
+      "userId": "ID de usuario",
+      "username": "Nombre de usuario"
+    },
+    "settings": {
+      "dark": "Oscuro",
+      "language": "Idioma",
+      "light": "Claro",
+      "theme": "Tema"
     },
     "social": {
-      "title": "Social",
-      "searchPlaceholder": "Buscar usuarios",
-      "searchLabel": "Buscador",
-      "friends": {
-        "title": "Amigos",
-        "online": "Amigos conectados",
-        "offline": "Amigos desconectados"
-      },
-      "requests": {
-        "title": "Solicitudes",
-        "received": "Recibidas",
-        "sent": "Enviadas"
+      "actions": {
+        "accept": "Aceptar",
+        "addFriend": "Añadir amigo",
+        "cancel": "Cancelar",
+        "chat": "Chat",
+        "inviteToGame": "Invitar a partida",
+        "reject": "Rechazar"
       },
       "emptyStates": {
-        "online": "No hay amigos conectados",
         "offline": "No hay amigos desconectados",
-        "request": "No tienes solicitudes pendientes",
+        "online": "No hay amigos conectados",
         "pending": "No has enviado solicitudes",
+        "request": "No tienes solicitudes pendientes",
         "search": "No se han encontrado usuarios"
       },
-      "actions": {
-        "inviteToGame": "Invitar a partida",
-        "chat": "Chat",
-        "reject": "Rechazar",
-        "accept": "Aceptar",
-        "cancel": "Cancelar",
-        "addFriend": "Añadir amigo"
+      "friends": {
+        "offline": "Amigos desconectados",
+        "online": "Amigos conectados",
+        "title": "Amigos"
       },
       "guest": {
-        "title": "Conéctate con la comunidad",
         "body": "Para encontrar amigos, ver quién está conectado y jugar, necesitas una cuenta.",
         "login": "Iniciar sesión",
         "noAccount": "¿No tienes cuenta?",
-        "signup": "Crear una"
-      }
+        "signup": "Crear una",
+        "title": "Conéctate con la comunidad"
+      },
+      "requests": {
+        "received": "Recibidas",
+        "sent": "Enviadas",
+        "title": "Solicitudes"
+      },
+      "searchLabel": "Buscador",
+      "searchPlaceholder": "Buscar usuarios",
+      "title": "Social"
     }
   },
   "validation": {
-    "REQUIRED": "Este campo es obligatorio.",
+    "FIELD_TOO_LONG": "Demasiado largo.",
+    "FIELD_TOO_SHORT": "Demasiado corto.",
     "INVALID_EMAIL": "Introduce un correo electrónico válido.",
-    "INVALID_USERNAME": "El nombre de usuario debe tener entre 3 y 30 caracteres y solo puede contener letras, números, guiones bajos (_) o guiones (-).",
     "INVALID_EMAIL_OR_USERNAME": "Introduce un correo electrónico o nombre de usuario válido.",
     "INVALID_FORMAT": "Formato no válido.",
-    "USERNAME_TOO_SHORT": "El nombre de usuario debe tener al menos 3 caracteres.",
-    "USERNAME_TOO_LONG": "El nombre de usuario no puede superar los 30 caracteres.",
+    "INVALID_USERNAME": "El nombre de usuario debe tener entre 3 y 30 caracteres y solo puede contener letras, números, guiones bajos (_) o guiones (-).",
     "INVALID_USERNAME_FORMAT": "El nombre de usuario solo puede contener letras, números, guiones bajos (_) y guiones (-).",
-    "FIELD_TOO_SHORT": "Demasiado corto.",
-    "FIELD_TOO_LONG": "Demasiado largo.",
+    "OUT_OF_RANGE": "Solicitud fuera de rango.",
     "PASSWORDS_DO_NOT_MATCH": "Las contraseñas no coinciden.",
-    "OUT_OF_RANGE": "Solicitud fuera de rango."
+    "REQUIRED": "Este campo es obligatorio.",
+    "USERNAME_TOO_LONG": "El nombre de usuario no puede superar los 30 caracteres.",
+    "USERNAME_TOO_SHORT": "El nombre de usuario debe tener al menos 3 caracteres."
   },
   "errors": {
-    "AUTH_EMAIL_ALREADY_EXISTS": "El correo electrónico ya existe",
-    "AUTH_INVALID_CREDENTIALS": "Credenciales inválidas",
     "AUTH_ACCOUNT_LOCKED": "Tu cuenta está bloqueada temporalmente. Inténtalo más tarde.",
-    "AUTH_RATE_LIMITED": "Demasiados intentos. Inténtalo más tarde.",
-    "AUTH_NO_PENDING_RECOVER": "No se encontró ninguna solicitud de restablecimiento. Empieza de nuevo.",
+    "AUTH_EMAIL_ALREADY_EXISTS": "El correo electrónico ya existe",
     "AUTH_EMAIL_NOT_VERIFIED": "Verifica tu correo antes de iniciar sesión.",
-    "AUTH_TOKEN_EXPIRED": "El enlace de verificación no es válido o ha caducado.",
-    "AUTH_UNAUTHORIZED": "Debes iniciar sesión para ver este contenido.",
     "AUTH_FORBIDDEN": "No tienes permiso para acceder a este recurso.",
     "AUTH_INTERNAL_ERROR": "Algo salió mal. Vuelve a intentarlo.",
-    "VALIDATION_ERROR": "Error de validación: revisa los campos e inténtalo de nuevo.",
+    "AUTH_INVALID_CREDENTIALS": "Credenciales inválidas",
+    "AUTH_NO_PENDING_RECOVER": "No se encontró ninguna solicitud de restablecimiento. Empieza de nuevo.",
+    "AUTH_RATE_LIMITED": "Demasiados intentos. Inténtalo más tarde.",
+    "AUTH_TOKEN_EXPIRED": "El enlace de verificación no es válido o ha caducado.",
+    "AUTH_UNAUTHORIZED": "Debes iniciar sesión para ver este contenido.",
     "FETCH_FAILED": "Ha fallado la solicitud a la API. Inténtalo de nuevo más tarde.",
-    "UNAUTHORIZED_ACTION": "Acción no permitida.",
-    "FRIENDSHIP_REQUEST_NOT_FOUND": "La solicitud no existe o ya no está disponible.",
     "FRIENDSHIP_ALREADY_ACCEPTED": "Esta solicitud ya ha sido aceptada.",
-    "FRIENDSHIP_NOT_FOUND": "No se ha encontrado la amistad.",
-    "USER_NOT_FOUND": "Usuario no encontrado.",
-    "INTERNAL_ERROR": "Algo salió mal. Vuelve a intentarlo.",
     "FRIENDSHIP_ALREADY_EXISTS": "Ya sois amigos.",
+    "FRIENDSHIP_NOT_FOUND": "No se ha encontrado la amistad.",
+    "FRIENDSHIP_REQUEST_ALREADY_SENT": "Ya se ha enviado una solicitud de amistad.",
+    "FRIENDSHIP_REQUEST_NOT_FOUND": "La solicitud no existe o ya no está disponible.",
     "FRIENDSHIP_SELF_REQUEST": "No puedes añadirte a ti mismo.",
-    "FRIENDSHIP_REQUEST_ALREADY_SENT": "Ya se ha enviado una solicitud de amistad."
+    "INTERNAL_ERROR": "Algo salió mal. Vuelve a intentarlo.",
+    "UNAUTHORIZED_ACTION": "Acción no permitida.",
+    "USER_NOT_FOUND": "Usuario no encontrado.",
+    "VALIDATION_ERROR": "Error de validación: revisa los campos e inténtalo de nuevo."
   }
 }


### PR DESCRIPTION
This pull request introduces a new automated workflow and supporting scripts for managing i18n (internationalization) string extraction, proposal generation, and locale patching in the frontend codebase. The changes add a custom ESLint configuration to enforce that all UI strings are internationalized, and three new scripts to facilitate the process of collecting i18n violations, generating AI-based translation proposals, producing output files, and applying locale patches. These updates aim to streamline and standardize the i18n process, reduce manual effort, and ensure consistency across supported languages.

**i18n Automation and Enforcement**

* Added a custom ESLint configuration file (`only-i18n-strings.config.mjs`) that enforces no literal UI strings in TypeScript/TSX files, with exceptions for certain paths, using a local ESLint rule.

**i18n Workflow Scripts**

* Introduced `build-ai-payload.mjs` to aggregate detected i18n violations, existing locale files, and project-specific i18n rules into a structured payload for AI translation proposal generation.
* Added `build-output-files.mjs` to process the AI-generated proposals, normalize and validate the data, and generate output files: translation proposals, locale patches for Catalan, English, and Spanish, and code patch suggestions.
* Implemented `apply-locale-patches.mjs` to apply the generated locale patches to the respective language JSON files, handling deep merges and reporting any key collisions or skipped files.