### PR TITLE
cambios realizaados

### DIFF
--- a/containers/backend/app/src/app.ts
+++ b/containers/backend/app/src/app.ts
@@ -10,6 +10,7 @@ import { protectedRouter } from './protected/protected.route';
 import './auth/oauth/oauth.passport';
 import { authRouter } from './auth/auth.routes';
 import { friendsRouter } from './friendships/friendships.routes';
+import { handleInternalFriendsList } from './friendships/friendships.presence';
 
 // Ensure required environment variables are set
 // TODO manage like in frontend with a env schema validator
@@ -61,6 +62,8 @@ app.use('/users', usersRouter);
 app.use('/auth', authRouter);
 app.use('/protected', protectedRouter);
 app.use('/friends', friendsRouter);
+
+app.post('/internal/friends', handleInternalFriendsList);
 
 app.use(errorMiddleware);
 

--- a/containers/backend/app/src/friendships/friendships.presence.ts
+++ b/containers/backend/app/src/friendships/friendships.presence.ts
@@ -1,4 +1,36 @@
+import type { Request, Response } from 'express';
+
+import { FriendshipFriendsListBodySchema } from '@contracts/sockets/friendships/friendships.schema';
+
+import { listFriendsForUser } from './friendships.repo';
+
 const SOCKET_SERVICE_URL = process.env.SOCKET_SERVICE_URL ?? 'https://socket:3100';
+
+export function handleInternalFriendsList(req: Request, res: Response): void {
+  const secret = process.env.SOCKET_INTERNAL_SECRET;
+  if (secret) {
+    const header = req.headers['x-internal-secret'];
+    if (header !== secret) {
+      res.status(401).json({ ok: false });
+      return;
+    }
+  }
+
+  const parsed = FriendshipFriendsListBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ ok: false, errors: parsed.error.flatten() });
+    return;
+  }
+
+  listFriendsForUser(parsed.data.userId)
+    .then((friends) => {
+      const friendIds = friends.map((f) => f.id);
+      res.json({ ok: true, data: { friendIds } });
+    })
+    .catch(() => {
+      res.status(500).json({ ok: false });
+    });
+}
 
 export async function resolveOnlineStatus(userIds: string[]): Promise<Record<string, boolean>> {
   if (userIds.length === 0) return {};

--- a/containers/backend/app/src/friendships/friendships.presence.ts
+++ b/containers/backend/app/src/friendships/friendships.presence.ts
@@ -8,12 +8,12 @@ const SOCKET_SERVICE_URL = process.env.SOCKET_SERVICE_URL ?? 'https://socket:310
 
 export function handleInternalFriendsList(req: Request, res: Response): void {
   const secret = process.env.SOCKET_INTERNAL_SECRET;
-  if (secret) {
-    const header = req.headers['x-internal-secret'];
-    if (header !== secret) {
-      res.status(401).json({ ok: false });
-      return;
-    }
+  if (!secret) {
+    console.warn('[internal/friends] SOCKET_INTERNAL_SECRET is not set — endpoint is unprotected');
+  }
+  if (secret && req.headers['x-internal-secret'] !== secret) {
+    res.status(401).json({ ok: false });
+    return;
   }
 
   const parsed = FriendshipFriendsListBodySchema.safeParse(req.body);

--- a/containers/contracts/sockets/friendships/friendships.schema.ts
+++ b/containers/contracts/sockets/friendships/friendships.schema.ts
@@ -6,6 +6,13 @@ export const friendshipSocketEvents = {
   rejected: 'friends:rejected',
 } as const;
 
+export const presenceSocketEvents = {
+  online: 'user:online',
+  away: 'user:away',
+  offline: 'user:offline',
+  active: 'user:active',
+} as const;
+
 export type FriendshipSocketEvent =
   (typeof friendshipSocketEvents)[keyof typeof friendshipSocketEvents];
 
@@ -51,8 +58,48 @@ export type FriendshipSocketPayloadByEvent = {
   >;
 };
 
+// ---------------------------------------------------------------------------
+// Presence schemas
+// ---------------------------------------------------------------------------
+
+export const PresenceOnlinePayloadSchema = z.strictObject({
+  userId: z.string().uuid(),
+  username: z.string().min(1),
+});
+
+export type PresenceOnlinePayload = z.infer<typeof PresenceOnlinePayloadSchema>;
+
+export const PresenceAwayPayloadSchema = z.strictObject({
+  userId: z.string().uuid(),
+});
+
+export type PresenceAwayPayload = z.infer<typeof PresenceAwayPayloadSchema>;
+
+export const PresenceOfflinePayloadSchema = z.strictObject({
+  userId: z.string().uuid(),
+});
+
+export type PresenceOfflinePayload = z.infer<typeof PresenceOfflinePayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// Server -> Client events (friendship notifications + presence)
+// ---------------------------------------------------------------------------
+
 export type ServerToClientFriendshipEvents = {
   [K in FriendshipSocketEvent]: (payload: FriendshipSocketPayloadByEvent[K]) => void;
+} & {
+  [presenceSocketEvents.online]: (payload: PresenceOnlinePayload) => void;
+  [presenceSocketEvents.away]: (payload: PresenceAwayPayload) => void;
+  [presenceSocketEvents.offline]: (payload: PresenceOfflinePayload) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Client -> Server events (presence signals)
+// ---------------------------------------------------------------------------
+
+export type ClientToServerFriendshipEvents = {
+  [presenceSocketEvents.away]: () => void;
+  [presenceSocketEvents.active]: () => void;
 };
 
 const FriendRequestNotifyBodySchema = z.strictObject({
@@ -86,3 +133,9 @@ export const FriendshipPresenceCheckBodySchema = z.strictObject({
 });
 
 export type FriendshipPresenceCheckBody = z.infer<typeof FriendshipPresenceCheckBodySchema>;
+
+export const FriendshipFriendsListBodySchema = z.strictObject({
+  userId: friendshipSocketUserIdSchema,
+});
+
+export type FriendshipFriendsListBody = z.infer<typeof FriendshipFriendsListBodySchema>;

--- a/containers/socket/app/src/features/friends.socket.ts
+++ b/containers/socket/app/src/features/friends.socket.ts
@@ -6,19 +6,26 @@ import {
   FriendRequestNotificationPayloadSchema,
   friendshipSocketEvents,
   friendshipSocketUserIdSchema,
+  presenceSocketEvents,
+  type ClientToServerFriendshipEvents,
   type FriendshipSocketEvent,
   type FriendshipSocketPayloadByEvent,
   type ServerToClientFriendshipEvents,
 } from '@contracts/sockets/friendships/friendships.schema';
 import { logEvents } from '../socket.logs';
-
-type ClientToServerFriendshipEvents = Record<string, never>;
+import { fetchAcceptedFriendIds } from '../internal/friends.client';
 
 let friendsNsp: Namespace<ClientToServerFriendshipEvents, ServerToClientFriendshipEvents> | null =
   null;
 
-/** userId -> number of active /friends connections that identified as that user */
+/** userId -> number of active /friends connections */
 const onlineCounts = new Map<string, number>();
+
+/** userId -> current presence state */
+const userStates = new Map<string, 'online' | 'away'>();
+
+/** userId -> username (cached from socket.data on first connection) */
+const usernames = new Map<string, string>();
 
 export function registerFriendsSocket(
   nsp: Namespace<ClientToServerFriendshipEvents, ServerToClientFriendshipEvents>,
@@ -41,17 +48,53 @@ export function registerFriendsSocket(
       }
 
       const currentUserId = parsedUserId.data;
+      const username: string = socket.data.username ?? 'unknown';
 
+      const wasOffline = (onlineCounts.get(currentUserId) ?? 0) === 0;
       incrementOnline(currentUserId);
+      usernames.set(currentUserId, username);
+
       void socket.join(`user:${currentUserId}`);
+      void socket.join(`status:${currentUserId}`);
+
       logEvents.info({
         event: 'friends_socket_connected',
         userId: currentUserId,
         socketId: socket.id,
       });
 
+      setupPresenceForSocket(socket, currentUserId, username, wasOffline);
+
+      socket.on(presenceSocketEvents.away, () => {
+        userStates.set(currentUserId, 'away');
+        friendsNsp?.to(`status:${currentUserId}`).emit(presenceSocketEvents.away, {
+          userId: currentUserId,
+        });
+        logEvents.info({ event: 'presence_away', userId: currentUserId });
+      });
+
+      socket.on(presenceSocketEvents.active, () => {
+        userStates.set(currentUserId, 'online');
+        friendsNsp?.to(`status:${currentUserId}`).emit(presenceSocketEvents.online, {
+          userId: currentUserId,
+          username,
+        });
+        logEvents.info({ event: 'presence_active', userId: currentUserId });
+      });
+
       socket.on('disconnect', () => {
         decrementOnline(currentUserId);
+        const isNowOffline = (onlineCounts.get(currentUserId) ?? 0) === 0;
+
+        if (isNowOffline) {
+          userStates.delete(currentUserId);
+          usernames.delete(currentUserId);
+          friendsNsp?.to(`status:${currentUserId}`).emit(presenceSocketEvents.offline, {
+            userId: currentUserId,
+          });
+          logEvents.info({ event: 'presence_offline', userId: currentUserId });
+        }
+
         logEvents.info({
           event: 'friends_socket_disconnected',
           userId: currentUserId,
@@ -60,6 +103,70 @@ export function registerFriendsSocket(
       });
     },
   );
+}
+
+async function setupPresenceForSocket(
+  socket: Socket<ClientToServerFriendshipEvents, ServerToClientFriendshipEvents>,
+  currentUserId: string,
+  username: string,
+  wasOffline: boolean,
+): Promise<void> {
+  const friendIds = await fetchAcceptedFriendIds(currentUserId);
+
+  for (const friendId of friendIds) {
+    void socket.join(`status:${friendId}`);
+  }
+
+  if (wasOffline) {
+    userStates.set(currentUserId, 'online');
+    friendsNsp?.to(`status:${currentUserId}`).emit(presenceSocketEvents.online, {
+      userId: currentUserId,
+      username,
+    });
+  }
+
+  for (const friendId of friendIds) {
+    const count = onlineCounts.get(friendId) ?? 0;
+    if (count > 0) {
+      const state = userStates.get(friendId) ?? 'online';
+      const friendUsername = usernames.get(friendId) ?? 'unknown';
+      if (state === 'away') {
+        socket.emit(presenceSocketEvents.away, { userId: friendId });
+      } else {
+        socket.emit(presenceSocketEvents.online, {
+          userId: friendId,
+          username: friendUsername,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Subscribe a user's sockets to a new friend's status room.
+ * Called when a friendship is accepted so both sides start receiving presence.
+ */
+export function subscribeUserToFriendStatus(userId: string, friendId: string): void {
+  if (!friendsNsp) return;
+
+  const userRoom = `user:${userId}`;
+  const friendStatusRoom = `status:${friendId}`;
+
+  friendsNsp.in(userRoom).socketsJoin(friendStatusRoom);
+
+  const friendCount = onlineCounts.get(friendId) ?? 0;
+  if (friendCount > 0) {
+    const state = userStates.get(friendId) ?? 'online';
+    const friendUsername = usernames.get(friendId) ?? 'unknown';
+    if (state === 'away') {
+      friendsNsp.to(userRoom).emit(presenceSocketEvents.away, { userId: friendId });
+    } else {
+      friendsNsp.to(userRoom).emit(presenceSocketEvents.online, {
+        userId: friendId,
+        username: friendUsername,
+      });
+    }
+  }
 }
 
 function incrementOnline(userId: string) {

--- a/containers/socket/app/src/features/friends.socket.ts
+++ b/containers/socket/app/src/features/friends.socket.ts
@@ -55,7 +55,6 @@ export function registerFriendsSocket(
       usernames.set(currentUserId, username);
 
       void socket.join(`user:${currentUserId}`);
-      void socket.join(`status:${currentUserId}`);
 
       logEvents.info({
         event: 'friends_socket_connected',
@@ -63,7 +62,16 @@ export function registerFriendsSocket(
         socketId: socket.id,
       });
 
-      setupPresenceForSocket(socket, currentUserId, username, wasOffline);
+      void setupPresenceForSocket(socket, currentUserId, username, wasOffline).catch(
+        (error: unknown) => {
+          logEvents.error({
+            event: 'setup_presence_for_socket_failed',
+            userId: currentUserId,
+            socketId: socket.id,
+            error,
+          });
+        },
+      );
 
       socket.on(presenceSocketEvents.away, () => {
         userStates.set(currentUserId, 'away');

--- a/containers/socket/app/src/internal/friends.client.ts
+++ b/containers/socket/app/src/internal/friends.client.ts
@@ -1,0 +1,32 @@
+const BACKEND_URL = process.env.BACKEND_URL ?? 'https://backend:4000';
+
+export async function fetchAcceptedFriendIds(userId: string): Promise<string[]> {
+  try {
+    const secret = process.env.SOCKET_INTERNAL_SECRET;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (secret) headers['x-internal-secret'] = secret;
+
+    const res = await fetch(`${BACKEND_URL}/internal/friends`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ userId }),
+    });
+
+    if (!res.ok) {
+      console.warn('[friends.client] backend /internal/friends failed', res.status);
+      return [];
+    }
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { friendIds: string[] };
+    };
+
+    return body.data?.friendIds ?? [];
+  } catch (error) {
+    console.error('[friends.client] error fetching friend ids', error);
+    return [];
+  }
+}

--- a/containers/socket/app/src/internal/friends.client.ts
+++ b/containers/socket/app/src/internal/friends.client.ts
@@ -1,3 +1,5 @@
+import { logEvents } from '../socket.logs';
+
 const BACKEND_URL = process.env.BACKEND_URL ?? 'https://backend:4000';
 
 export async function fetchAcceptedFriendIds(userId: string): Promise<string[]> {
@@ -15,7 +17,11 @@ export async function fetchAcceptedFriendIds(userId: string): Promise<string[]> 
     });
 
     if (!res.ok) {
-      console.warn('[friends.client] backend /internal/friends failed', res.status);
+      logEvents.warn({
+        event: 'fetch_accepted_friends_failed',
+        userId,
+        status: res.status,
+      });
       return [];
     }
 
@@ -26,7 +32,11 @@ export async function fetchAcceptedFriendIds(userId: string): Promise<string[]> 
 
     return body.data?.friendIds ?? [];
   } catch (error) {
-    console.error('[friends.client] error fetching friend ids', error);
+    logEvents.error({
+      event: 'fetch_accepted_friends_error',
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return [];
   }
 }

--- a/containers/socket/app/src/internal/notify.routes.ts
+++ b/containers/socket/app/src/internal/notify.routes.ts
@@ -53,7 +53,6 @@ export function handleInternalNotify(req: Request, res: Response): void {
     case friendshipSocketEvents.accepted:
       emitToUser(body.userId, body.event, body.payload);
       subscribeUserToFriendStatus(body.userId, body.payload.friendUserId);
-      subscribeUserToFriendStatus(body.payload.friendUserId, body.userId);
       break;
     case friendshipSocketEvents.rejected:
       emitToUser(body.userId, body.event, body.payload);

--- a/containers/socket/app/src/internal/notify.routes.ts
+++ b/containers/socket/app/src/internal/notify.routes.ts
@@ -5,7 +5,7 @@ import {
   FriendshipPresenceCheckBodySchema,
   friendshipSocketEvents,
 } from '@contracts/sockets/friendships/friendships.schema';
-import { emitToUser, getUsersOnlineStatus } from '../features/friends.socket';
+import { emitToUser, getUsersOnlineStatus, subscribeUserToFriendStatus } from '../features/friends.socket';
 import { logEvents } from '../socket.logs';
 
 function respondBadRequest(res: Response, error: { flatten: () => unknown }): void {
@@ -52,6 +52,8 @@ export function handleInternalNotify(req: Request, res: Response): void {
       break;
     case friendshipSocketEvents.accepted:
       emitToUser(body.userId, body.event, body.payload);
+      subscribeUserToFriendStatus(body.userId, body.payload.friendUserId);
+      subscribeUserToFriendStatus(body.payload.friendUserId, body.userId);
       break;
     case friendshipSocketEvents.rejected:
       emitToUser(body.userId, body.event, body.payload);


### PR DESCRIPTION
📋 Funcionalidades implementadas
Eventos de presencia en friendships.schema.ts:

Server→Client: user:online, user:away, user:offline
Client→Server: user:away, user:active
Endpoint interno POST /internal/friends en el backend que devuelve la lista de amigos aceptados

Lógica de presencia en el socket service:

Rooms status:{userId} para difusión solo a amigos
Consolidación multi-dispositivo (online/offline solo cuando cuenta pasa de/a 0)
Estado inicial enviado al conectarse
Suscripción dinámica al aceptar amistad
Todas las reglas de negocio cumplidas:

Solo amigos mutuos reciben notificaciones
Manejo correcto de múltiples sesiones
Away/Active como señales explícitas del cliente
El único warning es el unhealthy del backend debido a que ca.pem falta para el health check, pero es un problema pre-existente no relacionado con estos cambios. Los servicios están operativos y los endpoints funcionan correctamente.