### PR TITLE
292 chat feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ALL_ENV_FILES = \
 	prod prod-build prod-build-no-cache prod-down prod-clean prod-logs prod-ps \
 	up down clean fclean re \
 	logs logs-frontend logs-api logs-nginx logs-db logs-last logs-frontend-last logs-split \
-	db-reset db-seed db-push db-setup \
+	db-reset db-seed db-push db-setup prisma-generate \
 	clean-env clean-all-env \
 	ps restart shell-frontend shell-api shell-db shell-socket setup stop \
 	node-modules node-modules-backend node-modules-frontend node-modules-socket \
@@ -233,6 +233,9 @@ shell-socket:
 
 db-push:
 	$(COMPOSE_DEV) exec backend npm run prisma:db:push:dev
+
+prisma-generate:
+	$(COMPOSE_DEV) run --rm backend npm run prisma:generate
 
 db-seed:
 	$(COMPOSE_DEV) exec backend npm run db:seed:dev

--- a/containers/backend/app/prisma/schema.prisma
+++ b/containers/backend/app/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   friendships_as_user1 Friendship[] @relation("FriendshipUser1")
   friendships_as_user2 Friendship[] @relation("FriendshipUser2")
   friendships_sent     Friendship[] @relation("FriendshipSender")
+  directMessagesSent   DirectMessage[]
 
   @@map("users")
 }
@@ -56,11 +57,27 @@ model Friendship {
   user1  User @relation("FriendshipUser1", fields: [userId1], references: [id], onDelete: Cascade)
   user2  User @relation("FriendshipUser2", fields: [userId2], references: [id], onDelete: Cascade)
   sender User @relation("FriendshipSender", fields: [senderId], references: [id], onDelete: Cascade)
+  directMessages DirectMessage[]
 
   @@unique([userId1, userId2], name: "friendships_pair_uniq")
   @@index([userId1, status], name: "friendships_user1_status_idx")
   @@index([userId2, status], name: "friendships_user2_status_idx")
   @@map("friendships")
+}
+
+model DirectMessage {
+  id           String     @id @default(uuid()) @db.Uuid
+  friendshipId String     @map("friendship_id") @db.Uuid
+  senderId     String     @map("sender_id") @db.Uuid
+  body         String     @db.VarChar(300)
+  createdAt    DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  friendship Friendship @relation(fields: [friendshipId], references: [id], onDelete: Cascade)
+  sender     User       @relation(fields: [senderId], references: [id], onDelete: Cascade)
+
+  @@index([friendshipId, createdAt], name: "direct_messages_friendship_created_idx")
+  @@index([senderId, createdAt], name: "direct_messages_sender_created_idx")
+  @@map("direct_messages")
 }
 
 model PasswordReset {

--- a/containers/backend/app/src/app.ts
+++ b/containers/backend/app/src/app.ts
@@ -11,6 +11,10 @@ import './auth/oauth/oauth.passport';
 import { authRouter } from './auth/auth.routes';
 import { friendsRouter } from './friendships/friendships.routes';
 import { handleInternalFriendsList } from './friendships/friendships.presence';
+import {
+  handleInternalDirectMessageHistory,
+  handleInternalDirectMessageSend,
+} from './direct-messages/direct-messages.internal';
 import { authIpRateLimit } from './auth/auth.rate-limit';
 
 // Ensure required environment variables are set
@@ -65,6 +69,8 @@ app.use('/protected', protectedRouter);
 app.use('/friends', friendsRouter);
 
 app.post('/internal/friends', handleInternalFriendsList);
+app.post('/internal/direct-messages/history', handleInternalDirectMessageHistory);
+app.post('/internal/direct-messages/send', handleInternalDirectMessageSend);
 
 app.use(errorMiddleware);
 

--- a/containers/backend/app/src/direct-messages/direct-messages.internal.ts
+++ b/containers/backend/app/src/direct-messages/direct-messages.internal.ts
@@ -1,0 +1,107 @@
+import type { Request, Response } from 'express';
+
+import {
+  DirectMessageSendBodySchema,
+  DirectMessageThreadBodySchema,
+} from '@contracts/sockets/direct-messages/direct-messages.schema';
+
+import { findFriendshipByPair } from '../friendships/friendships.repo';
+import { createDirectMessage, listDirectMessagesForFriendship } from './direct-messages.repo';
+
+function ensureInternalSecret(req: Request, res: Response): boolean {
+  const secret = process.env.SOCKET_INTERNAL_SECRET;
+
+  if (!secret) {
+    res.status(503).json({ ok: false });
+    return false;
+  }
+
+  if (req.headers['x-internal-secret'] !== secret) {
+    res.status(401).json({ ok: false });
+    return false;
+  }
+
+  return true;
+}
+
+export function handleInternalDirectMessageHistory(req: Request, res: Response): void {
+  if (!ensureInternalSecret(req, res)) return;
+
+  const parsed = DirectMessageThreadBodySchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    res.status(400).json({ ok: false, errors: parsed.error.flatten() });
+    return;
+  }
+
+  findFriendshipByPair(parsed.data.currentUserId, parsed.data.friendUserId)
+    .then(async (friendship) => {
+      if (!friendship || friendship.status !== 'accepted') {
+        res.status(403).json({ ok: false });
+        return;
+      }
+
+      const rows = await listDirectMessagesForFriendship(friendship.id);
+
+      res.json({
+        ok: true,
+        data: {
+          messages: rows.map((row) => ({
+            id: row.id,
+            createdAt: row.createdAt.getTime(),
+            senderId: row.senderId,
+            username: row.sender.username,
+            type: 'user' as const,
+            content: { text: row.body },
+          })),
+        },
+      });
+    })
+    .catch((error: unknown) => {
+      console.error('[direct-messages] failed to load history', error);
+      res.status(500).json({ ok: false });
+    });
+}
+
+export function handleInternalDirectMessageSend(req: Request, res: Response): void {
+  if (!ensureInternalSecret(req, res)) return;
+
+  const parsed = DirectMessageSendBodySchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    res.status(400).json({ ok: false, errors: parsed.error.flatten() });
+    return;
+  }
+
+  findFriendshipByPair(parsed.data.currentUserId, parsed.data.friendUserId)
+    .then(async (friendship) => {
+      if (!friendship || friendship.status !== 'accepted') {
+        res.status(403).json({ ok: false });
+        return;
+      }
+
+      const saved = await createDirectMessage({
+        friendshipId: friendship.id,
+        senderId: parsed.data.currentUserId,
+        body: parsed.data.text,
+      });
+
+      res.json({
+        ok: true,
+        data: {
+          message: {
+            id: saved.id,
+            createdAt: saved.createdAt.getTime(),
+            senderId: saved.senderId,
+            username: saved.sender.username,
+            type: 'user' as const,
+            content: { text: saved.body },
+          },
+        },
+      });
+    })
+    .catch((error: unknown) => {
+      console.error('[direct-messages] failed to save message', error);
+      res.status(500).json({ ok: false });
+    });
+}

--- a/containers/backend/app/src/direct-messages/direct-messages.repo.ts
+++ b/containers/backend/app/src/direct-messages/direct-messages.repo.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+
+export type DirectMessageRow = {
+  id: string;
+  senderId: string;
+  body: string;
+  createdAt: Date;
+  sender: {
+    username: string;
+  };
+};
+
+export async function listDirectMessagesForFriendship(
+  friendshipId: string,
+): Promise<DirectMessageRow[]> {
+  return prisma.directMessage.findMany({
+    where: { friendshipId },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      senderId: true,
+      body: true,
+      createdAt: true,
+      sender: {
+        select: {
+          username: true,
+        },
+      },
+    },
+  });
+}
+
+export async function createDirectMessage(args: {
+  friendshipId: string;
+  senderId: string;
+  body: string;
+}): Promise<DirectMessageRow> {
+  return prisma.directMessage.create({
+    data: {
+      friendshipId: args.friendshipId,
+      senderId: args.senderId,
+      body: args.body,
+    },
+    select: {
+      id: true,
+      senderId: true,
+      body: true,
+      createdAt: true,
+      sender: {
+        select: {
+          username: true,
+        },
+      },
+    },
+  });
+}

--- a/containers/contracts/sockets/direct-messages/direct-messages.schema.ts
+++ b/containers/contracts/sockets/direct-messages/direct-messages.schema.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+import { VALIDATION } from '../../api/http/validation';
+
+export const directMessageSocketEvents = {
+  send: 'dm:send',
+  message: 'dm:message',
+  history: 'dm:history',
+  error: 'dm:error',
+} as const;
+
+export const directMessageFriendUserIdSchema = z.string().uuid();
+
+export const DirectMessageSendSchema = z.strictObject({
+  clientMessageId: z.string().uuid(),
+  text: z
+    .string()
+    .trim()
+    .min(1, { message: VALIDATION.REQUIRED })
+    .max(300, { message: VALIDATION.FIELD_TOO_LONG })
+    .transform((value: string) => value.trim()),
+});
+
+export type DirectMessageSend = z.infer<typeof DirectMessageSendSchema>;
+
+export const DirectMessageThreadBodySchema = z.strictObject({
+  currentUserId: z.string().uuid(),
+  friendUserId: z.string().uuid(),
+});
+
+export type DirectMessageThreadBody = z.infer<typeof DirectMessageThreadBodySchema>;
+
+export const DirectMessageSendBodySchema = z.strictObject({
+  currentUserId: z.string().uuid(),
+  friendUserId: z.string().uuid(),
+  text: DirectMessageSendSchema.shape.text,
+});
+
+export type DirectMessageSendBody = z.infer<typeof DirectMessageSendBodySchema>;
+
+const DirectMessageBaseSchema = z.strictObject({
+  clientMessageId: z.string().uuid().optional(),
+  id: z.string().uuid(),
+  createdAt: z.number(),
+  senderId: z.string().uuid(),
+  username: z.string().min(1),
+});
+
+export const DirectMessageSchema = DirectMessageBaseSchema.extend({
+  type: z.literal('user'),
+  content: z.strictObject({
+    text: z.string(),
+  }),
+});
+
+export type DirectMessage = z.infer<typeof DirectMessageSchema>;
+
+export const DirectMessageHistorySchema = z.array(DirectMessageSchema);
+export type DirectMessageHistory = z.infer<typeof DirectMessageHistorySchema>;
+
+export const DirectMessageErrorSchema = DirectMessageBaseSchema.extend({
+  type: z.literal('error'),
+  content: z.strictObject({
+    text: z.literal('INVALID_DIRECT_MESSAGE'),
+  }),
+});
+
+export type DirectMessageError = z.infer<typeof DirectMessageErrorSchema>;
+
+export type ClientToServerDirectMessageEvents = {
+  [directMessageSocketEvents.send]: (payload: DirectMessageSend) => void;
+};
+
+export type ServerToClientDirectMessageEvents = {
+  [directMessageSocketEvents.message]: (payload: DirectMessage) => void;
+  [directMessageSocketEvents.history]: (payload: DirectMessageHistory) => void;
+  [directMessageSocketEvents.error]: (payload: DirectMessageError) => void;
+};

--- a/containers/docker-compose.demo.yml
+++ b/containers/docker-compose.demo.yml
@@ -5,7 +5,6 @@ services:
     command: npm run start
     environment:
       NODE_ENV: production
-      SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-https://localhost:8443}
       BACKEND_SESSION_IDENTITY_URL: https://backend:4000/auth/session/identity
     volumes:
       - ${CERT_DIR:-../certs}:/certs:ro

--- a/containers/docker-compose.dev.yml
+++ b/containers/docker-compose.dev.yml
@@ -3,8 +3,6 @@ services:
     build:
       target: dev
     command: npm run dev
-    environment:
-      SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-https://localhost:8443}
     volumes:
       - ./socket/app:/app
       - node_modules_socket:/app/node_modules

--- a/containers/docker-compose.prod.yml
+++ b/containers/docker-compose.prod.yml
@@ -4,7 +4,6 @@ services:
       target: prod
     environment:
       NODE_ENV: production
-      SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-https://localhost:8443}
       BACKEND_SESSION_IDENTITY_URL: https://backend:4000/auth/session/identity
     volumes:
       - ${CERT_DIR:-../certs}:/certs:ro

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       NODE_ENV: ${NODE_ENV:-development}
       CERT_DIR: /certs
       NODE_EXTRA_CA_CERTS: /certs/ca.pem
-      SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-https://localhost:8443}
       BACKEND_SESSION_IDENTITY_URL: https://backend:4000/auth/session/identity
     networks:
       - edge

--- a/containers/frontend/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/containers/frontend/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -28,7 +28,7 @@ export default async function SocialLayout({ children }: SocialLayoutProps) {
           className={cn(
             glassBackgroundStyles({ intensity: 'medium', blur: 'sm' }),
             glassBorderStyles(),
-            'h-full w-full overflow-hidden rounded-s-md border-r-0',
+            'h-full w-full overflow-hidden rounded-s-md border-r-0 pointer-events-auto',
           )}
         >
           {userId ? (

--- a/containers/frontend/web/src/app/[locale]/(public)/messages/[userId]/page.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/messages/[userId]/page.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable local/no-literal-ui-strings */
+import { DirectMessagesAccess, DirectMessagesFeature } from '@/features/direct-messages';
+import { MessagesLayout } from '@/features/direct-messages/messages-layout';
+import { getTranslations } from 'next-intl/server';
+import { getCurrentUserIdOrNull } from '@/features/auth/me/get-current-user-id-or-null';
+import { protectedMeAction } from '@/features/auth/me/protected.action';
+import { getFriendsList } from '@/features/social/actions/social.server.actions';
+
+export default async function MessagesPage({ params }: { params: Promise<{ userId: string }> }) {
+  const [{ userId: friendIdentifier }, currentUserId, me, friendsResult] = await Promise.all([
+    params,
+    getCurrentUserIdOrNull(),
+    protectedMeAction().catch(() => null),
+    getFriendsList(),
+  ]);
+
+  const friend = friendsResult.ok
+    ? friendsResult.data.friends.find(
+        (item) => item.username === friendIdentifier || item.id === friendIdentifier,
+      )
+    : undefined;
+  const t = await getTranslations('features.directMessages');
+
+  return (
+    <MessagesLayout
+      friends={friendsResult.ok ? friendsResult.data.friends : []}
+      selectedUsername={friend?.username ?? friendIdentifier}
+    >
+      {currentUserId && me?.ok && friendsResult.ok && friend ? (
+        <DirectMessagesFeature
+          friendUserId={friend.id}
+          friendUsername={friend.username}
+          currentUserId={currentUserId}
+          currentUsername={me.data.username}
+        />
+      ) : (
+        <DirectMessagesAccess
+          title={t('accessTitle')}
+          body={
+            currentUserId && me?.ok
+              ? t('accessBody.authenticated')
+              : t('accessBody.unauthenticated')
+          }
+        />
+      )}
+    </MessagesLayout>
+  );
+}

--- a/containers/frontend/web/src/app/[locale]/(public)/messages/page.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/messages/page.tsx
@@ -1,0 +1,41 @@
+import { DirectMessagesAccess, DirectMessagesFeature } from '@/features/direct-messages';
+import { MessagesLayout } from '@/features/direct-messages/messages-layout';
+import { getTranslations } from 'next-intl/server';
+import { getCurrentUserIdOrNull } from '@/features/auth/me/get-current-user-id-or-null';
+import { protectedMeAction } from '@/features/auth/me/protected.action';
+import { getFriendsList } from '@/features/social/actions/social.server.actions';
+
+export default async function MessagesIndexPage() {
+  const [currentUserId, me, friendsResult] = await Promise.all([
+    getCurrentUserIdOrNull(),
+    protectedMeAction().catch(() => null),
+    getFriendsList(),
+  ]);
+
+  const friends = friendsResult.ok ? friendsResult.data.friends : [];
+  const firstFriend = friends[0];
+
+  const t = await getTranslations('features.directMessages');
+
+  return (
+    <MessagesLayout friends={friends} selectedUsername={firstFriend?.username}>
+      {currentUserId && me?.ok && friends.length > 0 && firstFriend ? (
+        <DirectMessagesFeature
+          friendUserId={firstFriend.id}
+          friendUsername={firstFriend.username}
+          currentUserId={currentUserId}
+          currentUsername={me.data.username}
+        />
+      ) : (
+        <DirectMessagesAccess
+          title={t('accessTitle')}
+          body={
+            currentUserId && me?.ok
+              ? t('accessBody.authenticated')
+              : t('accessBody.unauthenticated')
+          }
+        />
+      )}
+    </MessagesLayout>
+  );
+}

--- a/containers/frontend/web/src/app/[locale]/layout.tsx
+++ b/containers/frontend/web/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { Providers } from '@/app/providers';
 import { NavigationServer } from '@/features/navigation';
 import { SocialProvider } from '@/providers/social-provider';
 import { initializeSocialData } from '@/providers/social-initializer';
+import { SocialSocketBridge } from '@/features/social/store/social-store.bridge';
 
 export async function generateMetadata({
   params,
@@ -49,6 +50,7 @@ export default async function LocaleLayout({
     <NextIntlClientProvider locale={locale}>
       <Providers locale={locale}>
         <SocialProvider initialData={socialInitialData}>
+          <SocialSocketBridge />
           <HtmlLangSync />
 
           <NavigationServer locale={locale} />

--- a/containers/frontend/web/src/components/composites/user-item/user-item.tsx
+++ b/containers/frontend/web/src/components/composites/user-item/user-item.tsx
@@ -11,20 +11,32 @@ export type UserItemProps = {
   subtitle?: string;
   children?: ReactNode;
   className?: string;
+  href?: string;
 };
 
-export function UserItem({ avatarUrl, username, subtitle, children, className }: UserItemProps) {
-  return (
+export function UserItem({
+  avatarUrl,
+  username,
+  subtitle,
+  children,
+  className,
+  href,
+}: UserItemProps) {
+  const stack = (
     <Stack direction="horizontal" align="center" gap="sm" className={userItemStyles({ className })}>
       <Avatar src={avatarUrl} />
 
       <div className="flex-1 self-start">
-        <InternalLink
-          href={`/other/${username}`}
-          className="no-underline !text-inherit font-body-sm font-bold"
-        >
-          {username}
-        </InternalLink>
+        {href ? (
+          <span className="!text-inherit font-body-sm font-bold">{username}</span>
+        ) : (
+          <InternalLink
+            href={`/other/${username}`}
+            className="no-underline !text-inherit font-body-sm font-bold"
+          >
+            {username}
+          </InternalLink>
+        )}
         {subtitle && (
           <Text variant="caption" as="p" color="tertiary">
             {subtitle}
@@ -34,5 +46,13 @@ export function UserItem({ avatarUrl, username, subtitle, children, className }:
 
       {children}
     </Stack>
+  );
+
+  return href ? (
+    <InternalLink href={href} className={className}>
+      {stack}
+    </InternalLink>
+  ) : (
+    stack
   );
 }

--- a/containers/frontend/web/src/components/controls/link/dynamic-internal-link.tsx
+++ b/containers/frontend/web/src/components/controls/link/dynamic-internal-link.tsx
@@ -42,7 +42,7 @@ export type DynamicInternalLinkProps = DynamicInternalLinkStyleProps &
 
 /**
  * Component for dynamic internal routes that don't fit the strict InternalLink typing.
- * Suitable for routes like /messages/{id} or /other/{username}
+ * Suitable for routes like /messages/{slug} or /other/{username}
  */
 export function DynamicInternalLink(args: DynamicInternalLinkProps) {
   const {

--- a/containers/frontend/web/src/features/chat/chat.header.tsx
+++ b/containers/frontend/web/src/features/chat/chat.header.tsx
@@ -13,9 +13,11 @@ export function ChatHeader(props: ChatHeaderProps) {
       <Text as="h2" variant="heading-sm">
         {room}
       </Text>
-      <Text as="p" variant="body-xs">
-        {participants.join(', ')}
-      </Text>
+      {participants.length !== 0 && (
+        <Text as="p" variant="body-xs">
+          {participants.join(', ')}
+        </Text>
+      )}
     </Stack>
   );
 }

--- a/containers/frontend/web/src/features/chat/chat.styles.ts
+++ b/containers/frontend/web/src/features/chat/chat.styles.ts
@@ -1,6 +1,6 @@
 export const chatStyles = {
   wrapper:
-    'h-full bg-white/50 backdrop-blur-sm rounded-xl overflow-hidden border-l border-gray-200 pointer-events-auto',
+    'h-full min-h-0 min-w-0 flex-1 backdrop-blur-sm rounded-xl overflow-hidden border-l border-gray-200/20 pointer-events-auto',
 
   header: {
     wrapper:

--- a/containers/frontend/web/src/features/direct-messages/direct-messages.access.tsx
+++ b/containers/frontend/web/src/features/direct-messages/direct-messages.access.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { InternalLink, Stack, Text } from '@components';
+import { useTranslations } from 'next-intl';
+
+import { directMessagesStyles } from './direct-messages.styles';
+
+type DirectMessagesAccessProps = {
+  title: string;
+  body: string;
+};
+
+export function DirectMessagesAccess({ title, body }: DirectMessagesAccessProps) {
+  const t = useTranslations('features.directMessages');
+
+  return (
+    <Stack gap="md" className={directMessagesStyles.access.wrapper} align="center" justify="center">
+      <Text as="h1" variant="heading-md" className={directMessagesStyles.access.title}>
+        {title}
+      </Text>
+      <Text color="secondary" variant="body-sm">
+        {body}
+      </Text>
+      <InternalLink href="/" as="button" variant="cta" w="auto">
+        {t('backToHome')}
+      </InternalLink>
+    </Stack>
+  );
+}

--- a/containers/frontend/web/src/features/direct-messages/direct-messages.styles.ts
+++ b/containers/frontend/web/src/features/direct-messages/direct-messages.styles.ts
@@ -1,0 +1,7 @@
+export const directMessagesStyles = {
+  access: {
+    wrapper:
+      'h-full p-5 pt-11 pointer-events-auto rounded-xl overflow-hidden border-l border-gray-200/20 w-full',
+    title: 'font-bold',
+  },
+};

--- a/containers/frontend/web/src/features/direct-messages/direct-messages.tsx
+++ b/containers/frontend/web/src/features/direct-messages/direct-messages.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Form, Stack, TextAreaField } from '@components';
+
+import type {
+  DirectMessage,
+  DirectMessageError,
+  DirectMessageHistory,
+  DirectMessageSend,
+} from '@/contracts/sockets/direct-messages/direct-messages.schema';
+import type { ChatMessageUnion } from '@/contracts/sockets/chat/chat.schema';
+import { ChatHeader } from '@/features/chat/chat.header';
+import { ChatMain } from '@/features/chat/chat.main';
+import { chatStyles } from '@/features/chat/chat.styles';
+import { directMessagesSocket } from '@/lib/sockets/direct-messages-socket.client';
+import { DirectMessagesSocketManager } from '@/lib/sockets/direct-messages-socket.manager';
+
+type DirectMessageContextValue = {
+  messages: DirectChatHistory;
+  value: string;
+  setValue: (value: string) => void;
+  sendMessage: () => void;
+};
+
+const DirectMessageContext = createContext<DirectMessageContextValue | null>(null);
+
+type DirectChatMessage = ChatMessageUnion & {
+  clientMessageId?: string;
+  senderId?: string;
+};
+
+type DirectChatHistory = DirectChatMessage[];
+
+type DirectMessagesFeatureProps = {
+  friendUserId: string;
+  friendUsername: string;
+  currentUserId: string;
+  currentUsername: string;
+};
+
+function toChatMessage(message: DirectMessage, currentUserId: string): DirectChatMessage {
+  return message.senderId === currentUserId ? { ...message, type: 'me' } : message;
+}
+
+function toChatHistory(history: DirectMessageHistory, currentUserId: string): DirectChatHistory {
+  return history.map((message: DirectMessage) => toChatMessage(message, currentUserId));
+}
+
+function optimisticDirectMessage(args: {
+  text: string;
+  clientMessageId: string;
+  currentUserId: string;
+  currentUsername: string;
+}): DirectChatMessage {
+  return {
+    id: `pending:${args.clientMessageId}`,
+    createdAt: Date.now(),
+    senderId: args.currentUserId,
+    username: args.currentUsername,
+    type: 'me',
+    clientMessageId: args.clientMessageId,
+    content: {
+      text: args.text,
+    },
+  };
+}
+
+function mergeMessages(
+  previous: DirectChatHistory,
+  incoming: DirectChatHistory,
+): DirectChatHistory {
+  const next = [...previous];
+  const indexById = new Map(next.map((message, index) => [message.id, index]));
+  const pendingIndexByClientId = new Map(
+    next.flatMap((message, index) =>
+      typeof message.clientMessageId === 'string'
+        ? [[message.clientMessageId, index] as const]
+        : [],
+    ),
+  );
+
+  for (const message of incoming) {
+    const pendingIndex =
+      typeof message.clientMessageId === 'string'
+        ? pendingIndexByClientId.get(message.clientMessageId)
+        : undefined;
+
+    if (pendingIndex !== undefined) {
+      next[pendingIndex] = message;
+      indexById.set(message.id, pendingIndex);
+      continue;
+    }
+
+    const existingIndex = indexById.get(message.id);
+
+    if (existingIndex !== undefined) {
+      next[existingIndex] = message;
+      continue;
+    }
+
+    next.push(message);
+    indexById.set(message.id, next.length - 1);
+  }
+
+  return [...next].sort((left, right) => left.createdAt - right.createdAt);
+}
+
+function useDirectMessageState(currentUserId: string) {
+  const [messages, setMessages] = useState<DirectChatHistory>([]);
+  const [value, setValue] = useState('');
+
+  const handleDirectMessage = useCallback(
+    (message: DirectMessage) =>
+      setMessages((previous) => mergeMessages(previous, [toChatMessage(message, currentUserId)])),
+    [currentUserId],
+  );
+
+  const handleDirectHistory = useCallback(
+    (history: DirectMessageHistory) =>
+      setMessages((previous) => mergeMessages(previous, toChatHistory(history, currentUserId))),
+    [currentUserId],
+  );
+
+  const handleDirectError = useCallback((error: DirectMessageError) => {
+    setMessages((previous) => [
+      ...previous,
+      {
+        id: error.id,
+        createdAt: error.createdAt,
+        senderId: error.senderId,
+        username: error.username,
+        type: 'error',
+        content: error.content,
+      },
+    ]);
+  }, []);
+
+  return {
+    messages,
+    value,
+    setValue,
+    setMessages,
+    handleDirectMessage,
+    handleDirectHistory,
+    handleDirectError,
+  };
+}
+
+function DirectMessagesContent({
+  friendUsername,
+}: {
+  friendUsername: string;
+  currentUsername: string;
+}) {
+  const t = useTranslations('features.chat');
+  const context = useContext(DirectMessageContext);
+
+  if (!context) {
+    throw new Error('DirectMessagesContent must be used within a DirectMessagesFeature');
+  }
+
+  const { messages, value, setValue, sendMessage } = context;
+
+  return (
+    <Stack gap="none" className={chatStyles.wrapper}>
+      <ChatHeader room={friendUsername} participants={[]} />
+      <ChatMain messages={messages} />
+      <Form
+        onSubmit={(event: FormEvent<HTMLFormElement>) => {
+          event.preventDefault();
+          sendMessage();
+        }}
+        className={chatStyles.footer.wrapper}
+      >
+        <TextAreaField
+          value={value}
+          onChange={setValue}
+          className={chatStyles.footer.input}
+          aria-label={t('messageAriaLabel')}
+          maxLength={300}
+          onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault();
+              sendMessage();
+            }
+          }}
+        />
+      </Form>
+    </Stack>
+  );
+}
+
+export function DirectMessagesFeature({
+  friendUserId,
+  friendUsername,
+  currentUserId,
+  currentUsername,
+}: DirectMessagesFeatureProps) {
+  const {
+    messages,
+    value,
+    setValue,
+    setMessages,
+    handleDirectMessage,
+    handleDirectHistory,
+    handleDirectError,
+  } = useDirectMessageState(currentUserId);
+
+  const sendMessage = useCallback(() => {
+    const text = value.trim();
+    if (!text) return;
+
+    const clientMessageId = crypto.randomUUID();
+    const payload: DirectMessageSend = { text, clientMessageId };
+
+    setMessages((previous) =>
+      mergeMessages(previous, [
+        optimisticDirectMessage({
+          text,
+          clientMessageId,
+          currentUserId,
+          currentUsername,
+        }),
+      ]),
+    );
+    directMessagesSocket.emit('dm:send', payload);
+    setValue('');
+  }, [currentUserId, currentUsername, setMessages, setValue, value]);
+
+  const contextValue = useMemo(
+    () => ({ messages, value, setValue, sendMessage }),
+    [messages, value, setValue, sendMessage],
+  );
+
+  return (
+    <DirectMessageContext.Provider value={contextValue}>
+      <DirectMessagesSocketManager
+        friendUserId={friendUserId}
+        onDirectMessage={handleDirectMessage}
+        onDirectHistory={handleDirectHistory}
+        onDirectError={handleDirectError}
+      />
+      <DirectMessagesContent friendUsername={friendUsername} currentUsername={currentUsername} />
+    </DirectMessageContext.Provider>
+  );
+}

--- a/containers/frontend/web/src/features/direct-messages/index.ts
+++ b/containers/frontend/web/src/features/direct-messages/index.ts
@@ -1,0 +1,2 @@
+export { DirectMessagesFeature } from './direct-messages';
+export { DirectMessagesAccess } from './direct-messages.access';

--- a/containers/frontend/web/src/features/direct-messages/messages-layout.tsx
+++ b/containers/frontend/web/src/features/direct-messages/messages-layout.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { FriendPublic } from '@/contracts/api/friendships/friendships.contracts';
+import { MessagesList } from './messages-list';
+
+type MessagesLayoutProps = {
+  friends: FriendPublic[];
+  selectedUsername?: string;
+  children: ReactNode;
+};
+
+export function MessagesLayout({ friends, selectedUsername, children }: MessagesLayoutProps) {
+  return (
+    <div className="pointer-events-auto flex w-full min-w-0 flex-1 h-[100dvh] overflow-hidden">
+      <div className="flex min-h-0 w-[400px] shrink-0 overflow-hidden ml-8">
+        <MessagesList friends={friends} selectedUsername={selectedUsername} />
+      </div>
+
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
+    </div>
+  );
+}

--- a/containers/frontend/web/src/features/direct-messages/messages-list.tsx
+++ b/containers/frontend/web/src/features/direct-messages/messages-list.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Stack, Text, ScrollArea, UserItem } from '@components';
+import type { FriendPublic } from '@/contracts/api/friendships/friendships.contracts';
+
+type MessagesListProps = {
+  friends: FriendPublic[];
+  selectedUsername?: string;
+};
+
+export function MessagesList({ friends, selectedUsername }: MessagesListProps) {
+  const t = useTranslations('features.directMessages');
+
+  return (
+    <Stack gap="none" className="w-full">
+      <Text as="h1" variant="heading-md" className="font-bold p-3">
+        {t('listTitle')}
+      </Text>
+      <ScrollArea className="flex-1">
+        <Stack gap="none">
+          {friends.length === 0 ? (
+            <Text color="secondary" variant="body-sm" className="p-3 text-center">
+              {t('emptyState')}
+            </Text>
+          ) : (
+            friends.map((friend) => (
+              <UserItem
+                key={friend.id}
+                href={`/messages/${friend.username}`}
+                className={`transition-colors no-underline ${
+                  selectedUsername === friend.username ? 'bg-slate-100/5' : 'hover:bg-gray-100/10'
+                }`}
+                username={friend.username}
+                avatarUrl={friend.avatar}
+                subtitle={
+                  friend.presence === 'online'
+                    ? t('presence.online')
+                    : friend.presence === 'away'
+                      ? t('presence.away')
+                      : t('presence.offline')
+                }
+              />
+            ))
+          )}
+        </Stack>
+      </ScrollArea>
+    </Stack>
+  );
+}

--- a/containers/frontend/web/src/features/locale-switcher/locale-switcher.tsx
+++ b/containers/frontend/web/src/features/locale-switcher/locale-switcher.tsx
@@ -59,7 +59,8 @@ export function LocaleSwitcher() {
     if (next === locale) return;
     if (next !== 'en' && next !== 'es' && next !== 'ca') return;
     document.cookie = `${envPublic.localeCookieName}=${next};path=/;max-age=${LOCALE_COOKIE_MAX_AGE}`;
-    router.replace(pathname, { locale: next });
+    const target = typeof window !== 'undefined' ? window.location.pathname : pathname;
+    router.replace(target, { locale: next });
   };
 
   const options = [

--- a/containers/frontend/web/src/features/navigation/navigation.config.ts
+++ b/containers/frontend/web/src/features/navigation/navigation.config.ts
@@ -1,7 +1,7 @@
 import type { IconName } from '@components';
 
 // features/navigation/navigation.config.ts
-type NavHref = '/' | '/robots' | '/login' | '/me' | '/game';
+type NavHref = '/' | '/robots' | '/login' | '/me' | '/game' | '/messages';
 
 export type NavItem = {
   href: NavHref;
@@ -16,7 +16,10 @@ const baseNavItems: NavItem[] = [
 
 const publicNavItems: NavItem[] = [{ href: '/login', key: 'login', exact: false, icon: 'logIn' }];
 
-const privateNavItems: NavItem[] = [{ href: '/me', key: 'profile', exact: false, icon: 'user' }];
+const privateNavItems: NavItem[] = [
+  { href: '/messages', key: 'messages', exact: false, icon: 'messages' },
+  { href: '/me', key: 'profile', exact: false, icon: 'user' },
+];
 
 export function getMainNavItems(isAuthenticated: boolean): NavItem[] {
   return [...baseNavItems, ...(isAuthenticated ? privateNavItems : publicNavItems)];

--- a/containers/frontend/web/src/features/profile/public-profile.client.tsx
+++ b/containers/frontend/web/src/features/profile/public-profile.client.tsx
@@ -10,12 +10,13 @@ import { useFriendshipActions } from '../social/friendship-actions/use-friendshi
 
 interface PublicProfileClientProps {
   userId: string;
+  username: string;
   bio: string | null;
 }
 
-export function PublicProfileClient({ userId, bio }: PublicProfileClientProps) {
+export function PublicProfileClient({ userId, username, bio }: PublicProfileClientProps) {
   const t = useTranslations('features.profile');
-  const actions = useFriendshipActions(userId);
+  const actions = useFriendshipActions({ userId, username });
 
   return (
     <Stack className={profileStyles.container} gap="md">

--- a/containers/frontend/web/src/features/profile/public-profile.tsx
+++ b/containers/frontend/web/src/features/profile/public-profile.tsx
@@ -29,7 +29,11 @@ export async function PublicProfile({ username }: PublicProfileProps) {
         <Avatar src={data.data.avatar} size="lg" />
         <Text as="h2">{data.data.username}</Text>
       </Stack>
-      <PublicProfileClient userId={data.data.id} bio={data.data.bio} />
+      <PublicProfileClient
+        userId={data.data.id}
+        username={data.data.username}
+        bio={data.data.bio}
+      />
     </Stack>
   );
 }

--- a/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.config.ts
+++ b/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.config.ts
@@ -6,6 +6,7 @@ import type {
 
 export function createFriendshipActions({
   userId,
+  username,
   status,
   t,
   handlers,
@@ -17,7 +18,7 @@ export function createFriendshipActions({
         key: 'message',
         type: 'link',
         label: t('message'),
-        href: `/messages/${userId}`,
+        href: `/messages/${username ?? userId}`,
       },
       {
         key: 'deleteFriend',

--- a/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.types.ts
+++ b/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.types.ts
@@ -54,6 +54,7 @@ export type FriendshipAction =
 
 export interface CreateFriendshipActionsArgs {
   userId: string;
+  username?: string;
   status: FriendshipStatus;
   t: (key: string) => string;
   handlers: FriendshipActionHandlers;

--- a/containers/frontend/web/src/features/social/friendship-actions/use-friendship-actions.ts
+++ b/containers/frontend/web/src/features/social/friendship-actions/use-friendship-actions.ts
@@ -10,7 +10,13 @@ import { createFriendshipActionHandlers } from './friendship-actions.handlers';
 import type { FriendshipActionError } from './friendship-actions.types';
 import { getFriendshipStatus } from './friendship-actions.utils';
 
-export function useFriendshipActions(userId: string) {
+export function useFriendshipActions({
+  userId,
+  username,
+}: {
+  userId: string;
+  username?: string;
+}) {
   const t = useTranslations('features.social.actions');
   const [error, setError] = useState<FriendshipActionError>();
 
@@ -25,6 +31,7 @@ export function useFriendshipActions(userId: string) {
   const friend = friends.find((item) => item.id === userId);
   const requestReceived = pendingReceived.find((item) => item.userId === userId);
   const requestSent = pendingSent.find((item) => item.userId === userId);
+  const resolvedUsername = username ?? friend?.username ?? requestReceived?.username ?? requestSent?.username;
 
   const handlers = createFriendshipActionHandlers({
     userId,
@@ -40,6 +47,7 @@ export function useFriendshipActions(userId: string) {
 
   return createFriendshipActions({
     userId,
+    username: resolvedUsername,
     t,
     error,
     handlers,

--- a/containers/frontend/web/src/features/social/social-dashboard.tsx
+++ b/containers/frontend/web/src/features/social/social-dashboard.tsx
@@ -19,7 +19,6 @@ import {
 import { UserSearch, UsersList, SocialError } from './social-variants';
 import type { SocialErrorCode } from './store/social-store.types';
 import { useSocialStore } from '@/providers/social-provider';
-import { SocialSocketBridge } from './store/social-store.bridge';
 import {
   formatRequestAge,
   mapFriendshipToListItem,
@@ -240,8 +239,7 @@ function SocialContent() {
 
 export function SocialDashboard() {
   return (
-    <Stack className="h-full min-h-0" gap="none">
-      <SocialSocketBridge />
+    <Stack className="h-full min-h-0 pointer-events-auto" gap="none">
       <SocialHeader />
       <main className="flex flex-1 min-h-0">
         <SocialContent />

--- a/containers/frontend/web/src/features/social/social-variants/social-friendship-actions.tsx
+++ b/containers/frontend/web/src/features/social/social-variants/social-friendship-actions.tsx
@@ -20,6 +20,7 @@ const classNameByAction: Partial<Record<FriendshipActionKey, string>> = {
 
 interface SocialFriendshipActionsProps {
   userId: string;
+  username: string;
 }
 
 type ButtonAction = Extract<FriendshipAction, { type: 'button' }>;
@@ -28,9 +29,9 @@ function isButtonAction(action: FriendshipAction): action is ButtonAction {
   return action.type === 'button';
 }
 
-export function SocialFriendshipActions({ userId }: SocialFriendshipActionsProps) {
+export function SocialFriendshipActions({ userId, username }: SocialFriendshipActionsProps) {
   const tErrors = useTranslations('errors');
-  const actions = useFriendshipActions(userId).filter(isButtonAction);
+  const actions = useFriendshipActions({ userId, username }).filter(isButtonAction);
 
   return (
     <>

--- a/containers/frontend/web/src/features/social/social-variants/social-guest-view.tsx
+++ b/containers/frontend/web/src/features/social/social-variants/social-guest-view.tsx
@@ -7,7 +7,7 @@ export function SocialGuestView() {
   const t = useTranslations('features.social.guest');
 
   return (
-    <Stack gap="md" className="h-full p-5 pt-11" align="center">
+    <Stack gap="md" className="h-full p-5 pt-11 pointer-events-auto" align="center">
       <Text as="h1" variant="heading-md" className="font-bold">
         {t('title')}
       </Text>

--- a/containers/frontend/web/src/features/social/social-variants/social-user-actions.tsx
+++ b/containers/frontend/web/src/features/social/social-variants/social-user-actions.tsx
@@ -10,11 +10,12 @@ import type { UsersListType } from './users-list';
 interface SocialUserActionsProps {
   type: UsersListType;
   userId: string;
+  username: string;
 }
 
-export function SocialUserActions({ type, userId }: SocialUserActionsProps) {
+export function SocialUserActions({ type, userId, username }: SocialUserActionsProps) {
   const t = useTranslations('features.social.actions');
-  const messageHref = `/messages/${userId}` as const;
+  const messageHref = `/messages/${username}` as const;
 
   return (
     <>
@@ -32,7 +33,7 @@ export function SocialUserActions({ type, userId }: SocialUserActionsProps) {
       )}
 
       {(type === 'request' || type === 'pending' || type === 'search') && (
-        <SocialFriendshipActions userId={userId} />
+        <SocialFriendshipActions userId={userId} username={username} />
       )}
     </>
   );

--- a/containers/frontend/web/src/features/social/social-variants/users-list.tsx
+++ b/containers/frontend/web/src/features/social/social-variants/users-list.tsx
@@ -34,7 +34,7 @@ export function UsersList({ items, type, feedback = true }: UsersListProps) {
 
         return (
           <UserItem username={username} avatarUrl={avatar ?? undefined} subtitle={subtitle} key={id}>
-            <SocialUserActions type={type} userId={userId} />
+            <SocialUserActions type={type} userId={userId} username={username} />
           </UserItem>
         );
       })}

--- a/containers/frontend/web/src/features/social/store/social-store.bridge.tsx
+++ b/containers/frontend/web/src/features/social/store/social-store.bridge.tsx
@@ -4,11 +4,16 @@ import { SocialSocketManager } from '@/lib/sockets/friends-socket.manager';
 import { useSocialStore } from '@/providers/social-provider';
 
 export function SocialSocketBridge() {
+  const currentUserId = useSocialStore((state) => state.currentUserId);
   const setFriendPresence = useSocialStore((state) => state.setFriendPresence);
 
   const receiveFriendRequest = useSocialStore((state) => state.receiveFriendRequest);
   const receiveFriendAccepted = useSocialStore((state) => state.receiveFriendAccepted);
   const receiveFriendRejected = useSocialStore((state) => state.receiveFriendRejected);
+
+  if (!currentUserId) {
+    return null;
+  }
 
   return (
     <SocialSocketManager

--- a/containers/frontend/web/src/i18n/messages/ca.json
+++ b/containers/frontend/web/src/i18n/messages/ca.json
@@ -248,6 +248,21 @@
       "messageAriaLabel": "Missatge",
       "showChat": "Mostra el xat"
     },
+    "directMessages": {
+      "emptyState": "Encara no hi ha converses",
+      "listTitle": "Missatges",
+      "accessTitle": "Missatges directes",
+      "accessBody": {
+        "authenticated": "Aquesta conversa només està disponible entre amics acceptats.",
+        "unauthenticated": "Has d'iniciar sessió per obrir un xat privat."
+      },
+      "backToHome": "Torna a l'inici",
+      "presence": {
+        "online": "● En línia",
+        "away": "● Ausent",
+        "offline": "Desconnectat"
+      }
+    },
     "game": {
       "endTurn": "Acabar torn",
       "healthLabel": "HP",
@@ -257,6 +272,7 @@
       "createAccount": "Crear compte",
       "game": "Joc",
       "home": "Inici",
+      "messages": "Missatges",
       "login": "Iniciar sessió",
       "logout": "Tancar sessió",
       "mainAriaLabel": "Navegació principal",

--- a/containers/frontend/web/src/i18n/messages/en.d.json.ts
+++ b/containers/frontend/web/src/i18n/messages/en.d.json.ts
@@ -250,6 +250,21 @@ declare const messages: {
       "messageAriaLabel": "Message",
       "showChat": "Show Chat"
     },
+    "directMessages": {
+      "emptyState": "No conversations yet",
+      "listTitle": "Messages",
+      "accessTitle": "Direct messages",
+      "accessBody": {
+        "authenticated": "This conversation is only available between accepted friends.",
+        "unauthenticated": "You need to be signed in to open a private chat."
+      },
+      "backToHome": "Back to home",
+      "presence": {
+        "online": "● Online",
+        "away": "● Away",
+        "offline": "Offline"
+      }
+    },
     "game": {
       "endTurn": "End turn",
       "healthLabel": "HP",
@@ -259,6 +274,7 @@ declare const messages: {
       "createAccount": "Create account",
       "game": "Game",
       "home": "Home",
+      "messages": "Messages",
       "login": "Log in",
       "logout": "Logout",
       "mainAriaLabel": "Main navigation",

--- a/containers/frontend/web/src/i18n/messages/en.json
+++ b/containers/frontend/web/src/i18n/messages/en.json
@@ -247,6 +247,21 @@
       "messageAriaLabel": "Message",
       "showChat": "Show Chat"
     },
+    "directMessages": {
+      "emptyState": "No conversations yet",
+      "listTitle": "Messages",
+      "accessTitle": "Direct messages",
+      "accessBody": {
+        "authenticated": "This conversation is only available between accepted friends.",
+        "unauthenticated": "You need to be signed in to open a private chat."
+      },
+      "backToHome": "Back to home",
+      "presence": {
+        "online": "● Online",
+        "away": "● Away",
+        "offline": "Offline"
+      }
+    },
     "game": {
       "endTurn": "End turn",
       "healthLabel": "HP",
@@ -256,6 +271,7 @@
       "createAccount": "Create account",
       "game": "Game",
       "home": "Home",
+      "messages": "Messages",
       "login": "Log in",
       "logout": "Logout",
       "mainAriaLabel": "Main navigation",

--- a/containers/frontend/web/src/i18n/messages/es.json
+++ b/containers/frontend/web/src/i18n/messages/es.json
@@ -247,6 +247,21 @@
       "messageAriaLabel": "Mensaje",
       "showChat": "Mostrar chat"
     },
+    "directMessages": {
+      "emptyState": "Todavia no hay conversaciones",
+      "listTitle": "Mensajes",
+      "accessTitle": "Mensajes directos",
+      "accessBody": {
+        "authenticated": "Esta conversación solo está disponible entre amigos aceptados.",
+        "unauthenticated": "Necesitas iniciar sesión para abrir un chat privado."
+      },
+      "backToHome": "Volver al inicio",
+      "presence": {
+        "online": "● En línea",
+        "away": "● Ausente",
+        "offline": "Desconectado"
+      }
+    },
     "game": {
       "endTurn": "Terminar turno",
       "healthLabel": "HP",
@@ -256,6 +271,7 @@
       "createAccount": "Crear cuenta",
       "game": "Juego",
       "home": "Inicio",
+      "messages": "Mensajes",
       "login": "Iniciar sesión",
       "logout": "Cerrar sesión",
       "mainAriaLabel": "Navegación principal",

--- a/containers/frontend/web/src/i18n/routing.ts
+++ b/containers/frontend/web/src/i18n/routing.ts
@@ -81,6 +81,16 @@ export const routing = defineRouting({
       es: '/juego',
       ca: '/joc',
     },
+    '/messages': {
+      en: '/messages',
+      es: '/mensajes',
+      ca: '/missatges',
+    },
+    '/messages/[userId]': {
+      en: '/messages/[userId]',
+      es: '/messages/[userId]',
+      ca: '/messages/[userId]',
+    },
     '/other/[username]': {
       en: '/other/[username]',
       es: '/otro/[username]',

--- a/containers/frontend/web/src/lib/sockets/direct-messages-socket.client.ts
+++ b/containers/frontend/web/src/lib/sockets/direct-messages-socket.client.ts
@@ -1,0 +1,30 @@
+import { io, type Socket } from 'socket.io-client';
+
+import { envPublic } from '@/lib/config/env.public';
+import type {
+  ClientToServerDirectMessageEvents,
+  ServerToClientDirectMessageEvents,
+} from '@/contracts/sockets/direct-messages/direct-messages.schema';
+
+function createSocketUrl(pathname: string): string {
+  const baseUrl = typeof window === 'undefined' ? envPublic.socketUrl : window.location.origin;
+  return new URL(pathname, baseUrl).toString();
+}
+
+const directMessagesSocketUrl = createSocketUrl('/direct-messages');
+
+export const directMessagesSocket: Socket<
+  ServerToClientDirectMessageEvents,
+  ClientToServerDirectMessageEvents
+> = io(directMessagesSocketUrl, {
+  autoConnect: false,
+  transports: ['websocket'],
+  withCredentials: true,
+  auth: {},
+});
+
+export function disconnectDirectMessagesSocket() {
+  if (directMessagesSocket.connected) {
+    directMessagesSocket.disconnect();
+  }
+}

--- a/containers/frontend/web/src/lib/sockets/direct-messages-socket.manager.tsx
+++ b/containers/frontend/web/src/lib/sockets/direct-messages-socket.manager.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { ensureChatSessionIdentity } from './socket';
+import {
+  directMessageSocketEvents,
+  type DirectMessage,
+  type DirectMessageError,
+  type DirectMessageHistory,
+} from '@/contracts/sockets/direct-messages/direct-messages.schema';
+
+import { directMessagesSocket } from './direct-messages-socket.client';
+
+type DirectMessagesSocketManagerProps = {
+  friendUserId: string;
+  onDirectMessage: (message: DirectMessage) => void;
+  onDirectHistory: (history: DirectMessageHistory) => void;
+  onDirectError: (error: DirectMessageError) => void;
+};
+
+export function DirectMessagesSocketManager({
+  friendUserId,
+  onDirectMessage,
+  onDirectHistory,
+  onDirectError,
+}: DirectMessagesSocketManagerProps) {
+  useEffect(() => {
+    const handleConnect = () => {
+      console.log('✅ Connected to direct-messages socket server', directMessagesSocket.id);
+    };
+
+    const handleConnectError = (error: Error) => {
+      console.error('❌ Direct messages socket connect error:', error);
+    };
+
+    const handleDisconnect = (reason: string) => {
+      console.log('⚠️ Disconnected from direct-messages socket server:', reason);
+    };
+
+    const handleMessage = (message: DirectMessage) => {
+      console.log('📨 Received message:', message);
+      onDirectMessage(message);
+    };
+
+    const handleHistory = (history: DirectMessageHistory) => {
+      console.log('📜 Received history:', history.length, 'messages');
+      onDirectHistory(history);
+    };
+
+    const handleError = (error: DirectMessageError) => {
+      console.error('⚠️ Direct message error:', error);
+      onDirectError(error);
+    };
+
+    const reservedListeners = [
+      ['connect', handleConnect],
+      ['connect_error', handleConnectError],
+      ['disconnect', handleDisconnect],
+    ] as const;
+
+    const messageListeners = [
+      [directMessageSocketEvents.message, handleMessage],
+      [directMessageSocketEvents.history, handleHistory],
+      [directMessageSocketEvents.error, handleError],
+    ] as const;
+
+    let isMounted = true;
+
+    directMessagesSocket.auth = { friendUserId };
+    reservedListeners.forEach(([event, handler]) => directMessagesSocket.on(event, handler));
+    messageListeners.forEach(([event, handler]) => directMessagesSocket.on(event, handler));
+
+    void ensureChatSessionIdentity()
+      .catch((error) => {
+        console.error('Failed to initialize direct-messages session identity', error);
+      })
+      .finally(() => {
+        if (isMounted) {
+          directMessagesSocket.connect();
+        }
+      });
+
+    return () => {
+      isMounted = false;
+      reservedListeners.forEach(([event, handler]) => directMessagesSocket.off(event, handler));
+      messageListeners.forEach(([event, handler]) => directMessagesSocket.off(event, handler));
+      directMessagesSocket.disconnect();
+    };
+  }, [friendUserId, onDirectMessage, onDirectHistory, onDirectError]);
+
+  return null;
+}

--- a/containers/frontend/web/src/lib/sockets/friends-socket.client.ts
+++ b/containers/frontend/web/src/lib/sockets/friends-socket.client.ts
@@ -7,7 +7,12 @@ import type {
 } from '@/contracts/sockets/friendships/friendships.schema';
 import { envPublic } from '@/lib/config/env.public';
 
-const friendsSocketUrl = new URL('/friends', envPublic.socketUrl).toString();
+function createSocketUrl(pathname: string): string {
+  const baseUrl = typeof window === 'undefined' ? envPublic.socketUrl : window.location.origin;
+  return new URL(pathname, baseUrl).toString();
+}
+
+const friendsSocketUrl = createSocketUrl('/friends');
 
 export const friendsSocket: Socket<ServerToClientFriendshipEvents, ClientToServerFriendshipEvents> =
   io(friendsSocketUrl, {

--- a/containers/frontend/web/src/lib/sockets/friends-socket.manager.ts
+++ b/containers/frontend/web/src/lib/sockets/friends-socket.manager.ts
@@ -42,6 +42,10 @@ export const SocialSocketManager = ({
       emitCurrentPresence();
     };
 
+    const handleConnectError = (error: Error) => {
+      console.error('Friends socket connect error', error);
+    };
+
     const handleDisconnect = () => {
       console.log('Disconnected from friends socket server');
     };
@@ -72,6 +76,7 @@ export const SocialSocketManager = ({
 
     const reservedListeners = [
       ['connect', handleConnect],
+      ['connect_error', handleConnectError],
       ['disconnect', handleDisconnect],
     ] as const;
 

--- a/containers/frontend/web/src/lib/sockets/socket-manager.tsx
+++ b/containers/frontend/web/src/lib/sockets/socket-manager.tsx
@@ -71,6 +71,9 @@ export const ChatSocketManager = ({
 }: ChatSocketManagerProps) => {
   useEffect(() => {
     const handleConnect = () => console.log('Connected to chat socket server', chatSocket.id);
+    const handleConnectError = (error: Error) => {
+      console.error('Chat socket connect error', error);
+    };
     const handleDisconnect = () => console.log('Disconnected from chat socket server');
     const handleChatMessage = (payload: ChatMessage) => onChatMessage(payload);
     const handleChatSystemMessage = (payload: ChatSystemMessage) => onChatSystemMessage(payload);
@@ -81,6 +84,7 @@ export const ChatSocketManager = ({
 
     const reservedListeners = [
       ['connect', handleConnect],
+      ['connect_error', handleConnectError],
       ['disconnect', handleDisconnect],
     ] as const;
 

--- a/containers/frontend/web/src/lib/sockets/socket.ts
+++ b/containers/frontend/web/src/lib/sockets/socket.ts
@@ -51,10 +51,14 @@ export async function ensureChatSessionIdentity(): Promise<void> {
   return sessionPromise;
 }
 
-// TODO next doesn't like this change it after to something that next prefers.
-const robotsSocketUrl = window.location.origin + '/robots';
-const chatSocketUrl = window.location.origin + '/chat';
-const gameSocketUrl = window.location.origin + '/game';
+function createSocketUrl(pathname: string): string {
+  const baseUrl = typeof window === 'undefined' ? envPublic.socketUrl : window.location.origin;
+  return new URL(pathname, baseUrl).toString();
+}
+
+const robotsSocketUrl = createSocketUrl('/robots');
+const chatSocketUrl = createSocketUrl('/chat');
+const gameSocketUrl = createSocketUrl('/game');
 
 export const gameSocket: Socket<ServerToClientGameEvents, ClientToServerGameEvents> = io(
   gameSocketUrl,

--- a/containers/socket/app/src/features/direct-messages.socket.ts
+++ b/containers/socket/app/src/features/direct-messages.socket.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'crypto';
+
+import type { Namespace, Socket } from 'socket.io';
+import { z } from 'zod';
+
+import {
+  DirectMessageSendSchema,
+  directMessageSocketEvents,
+  type ClientToServerDirectMessageEvents,
+  type DirectMessageError,
+  type ServerToClientDirectMessageEvents,
+} from '@contracts/sockets/direct-messages/direct-messages.schema';
+
+import { fetchDirectMessageHistory, sendDirectMessage } from '../internal/direct-messages.client';
+import { fetchAcceptedFriendIds } from '../internal/friends.client';
+
+const friendUserIdSchema = z.string().uuid();
+
+function sortedPair(userId1: string, userId2: string): [string, string] {
+  return userId1 < userId2 ? [userId1, userId2] : [userId2, userId1];
+}
+
+function roomIdForPair(userId1: string, userId2: string): string {
+  const [smaller, larger] = sortedPair(userId1, userId2);
+  return `dm:${smaller}:${larger}`;
+}
+
+function errorMessage(): DirectMessageError {
+  return {
+    id: randomUUID(),
+    createdAt: Date.now(),
+    senderId: randomUUID(),
+    username: 'system',
+    type: 'error',
+    content: {
+      text: 'INVALID_DIRECT_MESSAGE',
+    },
+  };
+}
+
+export function registerDirectMessagesSocket(
+  nsp: Namespace<ClientToServerDirectMessageEvents, ServerToClientDirectMessageEvents>,
+) {
+  nsp.on(
+    'connection',
+    async (
+      socket: Socket<ClientToServerDirectMessageEvents, ServerToClientDirectMessageEvents>,
+    ) => {
+      const currentUserId = socket.data.userId;
+      const friendUserIdResult = friendUserIdSchema.safeParse(socket.handshake.auth?.friendUserId);
+
+      if (typeof currentUserId !== 'string' || currentUserId.length === 0) {
+        socket.disconnect(true);
+        return;
+      }
+
+      if (!friendUserIdResult.success || friendUserIdResult.data === currentUserId) {
+        socket.disconnect(true);
+        return;
+      }
+
+      const acceptedFriendIds = await fetchAcceptedFriendIds(currentUserId);
+
+      if (!acceptedFriendIds.includes(friendUserIdResult.data)) {
+        socket.disconnect(true);
+        return;
+      }
+
+      const roomId = roomIdForPair(currentUserId, friendUserIdResult.data);
+      await socket.join(roomId);
+
+      socket.on(directMessageSocketEvents.send, async (payload: unknown) => {
+        const parsed = DirectMessageSendSchema.safeParse(payload);
+
+        if (!parsed.success) {
+          socket.emit(directMessageSocketEvents.error, errorMessage());
+          return;
+        }
+
+        const saved = await sendDirectMessage({
+          currentUserId,
+          friendUserId: friendUserIdResult.data,
+          text: parsed.data.text,
+        });
+
+        if (!saved) {
+          socket.emit(directMessageSocketEvents.error, errorMessage());
+          return;
+        }
+
+        nsp.to(roomId).emit(directMessageSocketEvents.message, {
+          ...saved,
+          clientMessageId: parsed.data.clientMessageId,
+        });
+      });
+
+      const historyRows = await fetchDirectMessageHistory({
+        currentUserId,
+        friendUserId: friendUserIdResult.data,
+      });
+
+      socket.emit(directMessageSocketEvents.history, historyRows);
+    },
+  );
+}

--- a/containers/socket/app/src/internal/direct-messages.client.ts
+++ b/containers/socket/app/src/internal/direct-messages.client.ts
@@ -1,0 +1,96 @@
+import { logEvents } from '../socket.logs';
+
+import type {
+  DirectMessage,
+  DirectMessageHistory,
+} from '@contracts/sockets/direct-messages/direct-messages.schema';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'https://backend:4000';
+
+function getHeaders(): Record<string, string> {
+  const secret = process.env.SOCKET_INTERNAL_SECRET;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (secret) headers['x-internal-secret'] = secret;
+
+  return headers;
+}
+
+export async function fetchDirectMessageHistory(args: {
+  currentUserId: string;
+  friendUserId: string;
+}): Promise<DirectMessageHistory> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/internal/direct-messages/history`, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(args),
+    });
+
+    if (!res.ok) {
+      logEvents.warn({
+        event: 'fetch_direct_message_history_failed',
+        status: res.status,
+        currentUserId: args.currentUserId,
+        friendUserId: args.friendUserId,
+      });
+      return [];
+    }
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { messages: DirectMessage[] };
+    };
+
+    return body.data?.messages ?? [];
+  } catch (error) {
+    logEvents.error({
+      event: 'fetch_direct_message_history_error',
+      currentUserId: args.currentUserId,
+      friendUserId: args.friendUserId,
+      error,
+    });
+    return [];
+  }
+}
+
+export async function sendDirectMessage(args: {
+  currentUserId: string;
+  friendUserId: string;
+  text: string;
+}): Promise<DirectMessage | null> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/internal/direct-messages/send`, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(args),
+    });
+
+    if (!res.ok) {
+      logEvents.warn({
+        event: 'send_direct_message_failed',
+        status: res.status,
+        currentUserId: args.currentUserId,
+        friendUserId: args.friendUserId,
+      });
+      return null;
+    }
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { message: DirectMessage };
+    };
+
+    return body.data?.message ?? null;
+  } catch (error) {
+    logEvents.error({
+      event: 'send_direct_message_error',
+      currentUserId: args.currentUserId,
+      friendUserId: args.friendUserId,
+      error,
+    });
+    return null;
+  }
+}

--- a/containers/socket/app/src/sockets/socket.register.ts
+++ b/containers/socket/app/src/sockets/socket.register.ts
@@ -5,20 +5,24 @@ import { registerGameSocket } from '../features/game/game.socket';
 import { registerFriendsSocket } from '../features/friends.socket';
 import { registerChatSocket } from '../features/chat.socket';
 import { registerRobotsSocket } from '../features/robots.socket';
+import { registerDirectMessagesSocket } from '../features/direct-messages.socket';
 
 export function registerSockets(io: Server) {
   const friendsNsp = io.of('/friends');
   const robotsNsp = io.of('/robots');
   const gameNsp = io.of('/game');
   const chatNsp = io.of('/chat');
+  const directMessagesNsp = io.of('/direct-messages');
 
   friendsNsp.use(requireSessionSocketAuth);
   robotsNsp.use(requireSessionSocketAuth);
   gameNsp.use(attachOptionalChatIdentity);
   chatNsp.use(attachOptionalChatIdentity);
+  directMessagesNsp.use(requireSessionSocketAuth);
 
   registerFriendsSocket(friendsNsp);
   registerRobotsSocket(robotsNsp);
   registerChatSocket(chatNsp);
   registerGameSocket(gameNsp);
+  registerDirectMessagesSocket(directMessagesNsp);
 }

--- a/containers/socket/docker/.env.development.example
+++ b/containers/socket/docker/.env.development.example
@@ -3,3 +3,7 @@
 # -----------------------------
 # Must match backend SOCKET_INTERNAL_SECRET.
 SOCKET_INTERNAL_SECRET=change-me
+
+# Allowed browser origins for Socket.IO websocket connections.
+# In development this should usually match NEXT_PUBLIC_APP_URL.
+SOCKET_CORS_ORIGINS=https://localhost:8443

--- a/scripts/env/setup-env.sh
+++ b/scripts/env/setup-env.sh
@@ -313,6 +313,8 @@ NEXT_PUBLIC_LOCALE_COOKIE_NAME=locale
 
 EOF
 
+set_env_var "$SOCKET_ENV" "SOCKET_CORS_ORIGINS" "https://${HOST}:8443"
+
 echo "✅ Frontend env vars generated"
 
 echo


### PR DESCRIPTION
This pull request implements the backend and frontend infrastructure for direct messaging between friends, including database schema changes, backend API endpoints, frontend pages, and supporting utility code. The changes introduce a new `DirectMessage` model, secure internal endpoints for message history and sending, and new frontend routes and components for the direct messages UI.

**Backend: Direct Messaging Infrastructure**

* Added a new `DirectMessage` model to the Prisma schema, relating messages to friendships and senders, and updated the `User` and `Friendship` models with relevant relations. [[1]](diffhunk://#diff-83dff492b8f131eb0720d1f1858463b7bb68b09868737b6d64c725f860483e31R38) [[2]](diffhunk://#diff-83dff492b8f131eb0720d1f1858463b7bb68b09868737b6d64c725f860483e31R60-R82)
* Implemented repository functions for listing and creating direct messages in `direct-messages.repo.ts`.
* Added secure internal API endpoints for fetching direct message history and sending messages, with schema validation and friendship checks, in `direct-messages.internal.ts` and registered them in the Express app. [[1]](diffhunk://#diff-82585307d9a724016d76454f8fd849aa630f7b9cdf413a7fbd238563d715c220R1-R107) [[2]](diffhunk://#diff-fb433806c7b7e665f41f8e78ee376580b3f8faf3472eb4115655109679f973faR14-R17) [[3]](diffhunk://#diff-fb433806c7b7e665f41f8e78ee376580b3f8faf3472eb4115655109679f973faR72-R73)
* Added new zod schemas and socket event typings for direct messaging in the shared contracts.
* Updated the `Makefile` with a `prisma-generate` target for Prisma client generation. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L36-R36) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R237-R239)

**Frontend: Direct Messages UI**

* Introduced new pages for direct messages (`/messages` and `/messages/[userId]`), loading friends and conditionally rendering the messaging UI or access messages. ([containers/frontend/web/src/app/[locale]/(public)/messages/page.tsxR1-R41](diffhunk://#diff-a93e699faa44e31acce2603470ab1efaef7852ec424dead4e2de41390f996a6fR1-R41), [containers/frontend/web/src/app/[locale]/(public)/messages/[userId]/page.tsxR1-R48](diffhunk://#diff-1bcd12a6e0a09f159db338119ad12abb9d57ac4e70d1e1d48095c2b97de41669R1-R48))
* Integrated the `SocialSocketBridge` for real-time updates and ensured it is mounted in the main layout. ([containers/frontend/web/src/app/[locale]/layout.tsxR11](diffhunk://#diff-dbfd4d697b8de21505aef84326cfdd4564b2686a5eccab3809957b313fa25fd7R11), [containers/frontend/web/src/app/[locale]/layout.tsxR53](diffhunk://#diff-dbfd4d697b8de21505aef84326cfdd4564b2686a5eccab3809957b313fa25fd7R53))
* Updated the `UserItem` component to support linking to arbitrary URLs, enabling navigation to direct message threads. [[1]](diffhunk://#diff-e6dc500e1640c1e2875b82927ca05c8d90dee6e88bf38a8446a7afb39a2734fcR14-R39) [[2]](diffhunk://#diff-e6dc500e1640c1e2875b82927ca05c8d90dee6e88bf38a8446a7afb39a2734fcR50-R57)

**Other Improvements**

* Minor UI tweaks (e.g., pointer events in the dashboard layout, conditional chat header rendering). ([containers/frontend/web/src/app/[locale]/(dashboard)/layout.tsxL31-R31](diffhunk://#diff-028fa72443305e7bc56416cdc6dd0edfed1fac047a6ff422d3a177855c44e295L31-R31), [containers/frontend/web/src/features/chat/chat.header.tsxR16-R20](diffhunk://#diff-c695796d72cb121eed0bd078b8a36778486f80bcbe7ffb0db064f82bc028fd7dR16-R20))
* Cleaned up unused environment variables in Docker Compose files. [[1]](diffhunk://#diff-e50e6b024f3d8482922138b9facff2578b9bc9b03fd153495208c4a06f4e775bL8) [[2]](diffhunk://#diff-985e69379a224c5892d0e98da79c55b20ed89b1c55532ea7ec191bcfebdc6782L6-L7) [[3]](diffhunk://#diff-cb7e2093912019523c2f892d888ab564b326e67e221f8cd4b4294b8a04c6aa6cL7) [[4]](diffhunk://#diff-4adf198200e115c5823766ed487764919cfacba4b79d9390fd1e71c5c4ffb291L44)
* Clarified documentation for dynamic internal links.