### PR TITLE
feat: add public API with health check and user management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ _This project has been created as part of the 42 curriculum by cmanica-, [capape
 - [Resources](docs/resources.md)
 - [Environment setup](scripts/env/README.md)
 - [Frontend environment variables](docs/FE-env-variables.md)
+- [Backend public API](containers/backend/app/docs/public-api.md)
+- [Backend OpenAPI spec](containers/backend/app/docs/openapi.yaml)

--- a/containers/backend/app/docs/openapi.yaml
+++ b/containers/backend/app/docs/openapi.yaml
@@ -7,6 +7,7 @@ servers:
   - url: /
 tags:
   - name: Health
+  - name: Public API
   - name: Auth
   - name: Protected
   - name: Users
@@ -30,6 +31,262 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthErrorResponse'
+
+  /public-api/health:
+    get:
+      tags: [Public API]
+      summary: Public API health check
+      description: Validates the shared API key, then checks Redis and Postgres connectivity.
+      operationId: getPublicApiHealth
+      security:
+        - publicApiKey: []
+      responses:
+        '200':
+          description: Public API dependencies are healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicApiHealthResponse'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '500':
+          description: Redis, Postgres, or API key configuration is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+
+  /public-api/users:
+    get:
+      tags: [Public API]
+      summary: List public users through the API-key-protected public API
+      description: Read-only user listing protected by `x-api-key`.
+      operationId: getPublicApiUsers
+      security:
+        - publicApiKey: []
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          required: false
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+          required: false
+      responses:
+        '200':
+          description: Paginated user list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersListResponse'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+
+  /public-api/users/count:
+    get:
+      tags: [Public API]
+      summary: Count public users
+      operationId: getPublicApiUsersCount
+      security:
+        - publicApiKey: []
+      responses:
+        '200':
+          description: Total users count
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUsersCountResponse'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+
+  /public-api/users/search:
+    get:
+      tags: [Public API]
+      summary: Search users by username through the public API
+      description: Case-insensitive search protected by `x-api-key`. Rate limited per API key and client IP.
+      operationId: getPublicApiUsersSearch
+      security:
+        - publicApiKey: []
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 100
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+            default: 20
+      responses:
+        '200':
+          description: Matching public users
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUsersSearchResponse'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+
+  /public-api/users/{userId}:
+    get:
+      tags: [Public API]
+      summary: Get a public user by id through the API-key-protected public API
+      operationId: getPublicApiUserById
+      security:
+        - publicApiKey: []
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Public user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+
+  /public-api/users/username/{username}:
+    get:
+      tags: [Public API]
+      summary: Get a public user by username through the API-key-protected public API
+      operationId: getPublicApiUserByUsername
+      security:
+        - publicApiKey: []
+      parameters:
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorResponse'
 
   /auth/signup:
     post:
@@ -827,6 +1084,11 @@ components:
       type: apiKey
       in: cookie
       name: sid
+    publicApiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: Shared API key configured in the backend as `PUBLIC_API_KEY`.
   schemas:
     ApiError:
       type: object
@@ -883,6 +1145,23 @@ components:
         ok:
           type: boolean
           enum: [false]
+    PublicApiHealthResponse:
+      type: object
+      required: [ok, data]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          required: [database, redis]
+          properties:
+            database:
+              type: string
+              enum: [up]
+            redis:
+              type: string
+              enum: [up]
     NullResponse:
       type: object
       required: [ok, data]
@@ -1089,6 +1368,44 @@ components:
                 limit:
                   type: integer
                 offset:
+                  type: integer
+                count:
+                  type: integer
+    PublicUsersCountResponse:
+      type: object
+      required: [ok, data]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          required: [totalUsers]
+          properties:
+            totalUsers:
+              type: integer
+    PublicUsersSearchResponse:
+      type: object
+      required: [ok, data]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          required: [users, meta]
+          properties:
+            users:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserPublic'
+            meta:
+              type: object
+              required: [q, limit, count]
+              properties:
+                q:
+                  type: string
+                limit:
                   type: integer
                 count:
                   type: integer

--- a/containers/backend/app/docs/public-api.md
+++ b/containers/backend/app/docs/public-api.md
@@ -10,7 +10,7 @@ Send the API key in the `x-api-key` header:
 x-api-key: <PUBLIC_API_KEY>
 ```
 
-If `PUBLIC_API_KEY` is not configured, the public API fails closed and returns `500`.
+If `PUBLIC_API_KEY` is missing, the backend now fails fast during startup instead of booting with a broken public API.
 
 ## Rate limiting
 

--- a/containers/backend/app/docs/public-api.md
+++ b/containers/backend/app/docs/public-api.md
@@ -1,0 +1,74 @@
+# Public API
+
+This project now exposes a dedicated API-key-protected public API under `/public-api`.
+
+## Authentication
+
+Send the API key in the `x-api-key` header:
+
+```http
+x-api-key: <PUBLIC_API_KEY>
+```
+
+If `PUBLIC_API_KEY` is not configured, the public API fails closed and returns `500`.
+
+## Rate limiting
+
+All `/public-api` requests are rate limited in Redis per `x-api-key + client IP`.
+
+- Default global limit: `120` requests per `60` seconds
+- Default search limit: `30` requests per `60` seconds
+
+Optional environment variables:
+
+- `PUBLIC_API_KEY`
+- `PUBLIC_API_RATE_LIMIT_MAX`
+- `PUBLIC_API_RATE_LIMIT_WINDOW_MS`
+- `PUBLIC_API_SEARCH_RATE_LIMIT_MAX`
+- `PUBLIC_API_SEARCH_RATE_LIMIT_WINDOW_MS`
+
+## Endpoints
+
+| Method | Path | Description | DB-backed |
+| --- | --- | --- | --- |
+| `GET` | `/public-api/health` | Confirms Redis and Postgres are reachable | Yes |
+| `GET` | `/public-api/users` | Paginated public users list | Yes |
+| `GET` | `/public-api/users/count` | Total number of users | Yes |
+| `GET` | `/public-api/users/search?q=<query>&limit=<n>` | Public username search | Yes |
+| `GET` | `/public-api/users/username/:username` | Fetch a user by username | Yes |
+| `GET` | `/public-api/users/:userId` | Fetch a user by id | Yes |
+
+## Example
+
+```bash
+curl --cacert ./certs/ca.pem \
+  -H "x-api-key: $PUBLIC_API_KEY" \
+  "https://localhost:8443/api/public-api/users?limit=10&offset=0"
+```
+
+## Smoke Test From Host
+
+From the repo root:
+
+```bash
+./scripts/smoke-public-api.sh development
+./scripts/smoke-public-api.sh test
+```
+
+The wrapper runs the backend smoke suite from your host machine, loads `PUBLIC_API_KEY` from `containers/backend/docker/.env.<env>`, and trusts the local repo CA at `certs/ca.pem`.
+
+You can still override the target if needed, for example:
+
+```bash
+BASE_URL=https://localhost:8443/api/ ./scripts/smoke-public-api.sh development
+```
+
+Or override the CA bundle explicitly:
+
+```bash
+HOST_NODE_EXTRA_CA_CERTS=/absolute/path/to/ca.pem ./scripts/smoke-public-api.sh development
+```
+
+## OpenAPI
+
+The OpenAPI description for these endpoints lives in [openapi.yaml](./openapi.yaml).

--- a/containers/backend/app/package.json
+++ b/containers/backend/app/package.json
@@ -22,12 +22,16 @@
     "db:seed:test": "dotenv -e .env.test -- prisma db seed",
     "smoke:auth:dev": "dotenv -e .env.development -- tsx scripts/smoke/auth.smoke.ts",
     "smoke:friends:dev": "dotenv -e .env.development -- tsx scripts/smoke/friends.smoke.ts",
+    "smoke:public-api:host:dev": "dotenv -e ../docker/.env.development -- sh -c 'BASE_URL=\"${BASE_URL:-https://localhost:8443/api/}\" NODE_EXTRA_CA_CERTS=\"${HOST_NODE_EXTRA_CA_CERTS:-../../../certs/ca.pem}\" tsx scripts/smoke/public-api.smoke.ts'",
+    "smoke:public-api:dev": "npm run smoke:public-api:host:dev",
     "friends:accept:dev": "dotenv -e .env.development -- sh -c 'NODE_TLS_REJECT_UNAUTHORIZED=0 tsx scripts/friends.accept-seeded.ts'",
     "friends:accept:container": "dotenv -e .env.development -- sh -c 'BASE_URL=https://127.0.0.1:4000 NODE_TLS_REJECT_UNAUTHORIZED=0 tsx scripts/friends.accept-seeded.ts'",
     "smoke:auth:test": "dotenv -e .env.test -- tsx scripts/smoke/auth.smoke.ts",
     "smoke:friends:test": "dotenv -e .env.test -- tsx scripts/smoke/friends.smoke.ts",
-    "smoke:dev": "npm run prisma:db:push:dev && npm run db:seed:dev && npm run smoke:auth:dev && npm run smoke:friends:dev",
-    "smoke:test": "npm run db:reset:test && npm run prisma:db:push:test && npm run db:seed:test && npm run smoke:auth:test && npm run smoke:friends:test",
+    "smoke:public-api:host:test": "dotenv -e ../docker/.env.test -- sh -c 'BASE_URL=\"${BASE_URL:-https://localhost:8443/api/}\" NODE_EXTRA_CA_CERTS=\"${HOST_NODE_EXTRA_CA_CERTS:-../../../certs/ca.pem}\" tsx scripts/smoke/public-api.smoke.ts'",
+    "smoke:public-api:test": "npm run smoke:public-api:host:test",
+    "smoke:dev": "npm run prisma:db:push:dev && npm run db:seed:dev && npm run smoke:auth:dev && npm run smoke:friends:dev && npm run smoke:public-api:dev",
+    "smoke:test": "npm run db:reset:test && npm run prisma:db:push:test && npm run db:seed:test && npm run smoke:auth:test && npm run smoke:friends:test && npm run smoke:public-api:test",
     "smoke:friendships": "dotenv -e .env.development -- sh -c 'NODE_TLS_REJECT_UNAUTHORIZED=0 node scripts/smoke-friendships.mjs'"
   },
   "prisma": {

--- a/containers/backend/app/scripts/smoke/public-api.smoke.ts
+++ b/containers/backend/app/scripts/smoke/public-api.smoke.ts
@@ -1,0 +1,258 @@
+/* eslint-disable no-console */
+
+import { BASE_URL } from './smoke.config';
+import { request } from './smoke.request';
+import type { ApiResponse, TestResult } from './smoke.types';
+import { assert, logResponse, logStep, printSummary, runTest } from './smoke.utils';
+
+const PUBLIC_API_KEY = process.env.PUBLIC_API_TEST_KEY ?? process.env.PUBLIC_API_KEY;
+const SEEDED_USERNAME = process.env.PUBLIC_API_TEST_USERNAME ?? 'pikachu';
+const SEARCH_QUERY = process.env.PUBLIC_API_TEST_QUERY ?? 'pika';
+
+type UserPublic = {
+  id: string;
+  username: string;
+  avatar: string | null;
+  bio: string;
+};
+
+type PublicApiHealthOk = {
+  database: 'up';
+  redis: 'up';
+};
+
+type UsersListOk = {
+  users: UserPublic[];
+  meta: {
+    limit: number;
+    offset: number;
+    count: number;
+  };
+};
+
+type PublicUsersCountOk = {
+  totalUsers: number;
+};
+
+type PublicUsersSearchOk = {
+  users: UserPublic[];
+  meta: {
+    q: string;
+    limit: number;
+    count: number;
+  };
+};
+
+const results: TestResult[] = [];
+
+function requirePublicApiKey(): string {
+  assert(
+    Boolean(PUBLIC_API_KEY),
+    'Set PUBLIC_API_KEY or PUBLIC_API_TEST_KEY before running the public API smoke test',
+  );
+
+  return PUBLIC_API_KEY!;
+}
+
+async function requestPublicApi<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<{ res: Response; body: T | null; text: string }> {
+  const headers = new Headers(init.headers);
+  headers.set('x-api-key', requirePublicApiKey());
+
+  return request<T>(`public-api/${path}`, {
+    ...init,
+    headers,
+  });
+}
+
+async function requestPublicApiWithoutKey<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<{ res: Response; body: T | null; text: string }> {
+  const headers = new Headers(init.headers);
+  headers.delete('x-api-key');
+
+  return request<T>(`public-api/${path}`, {
+    ...init,
+    headers,
+  });
+}
+
+async function testRejectsMissingApiKey(): Promise<void> {
+  logStep('public API rejects requests without x-api-key');
+
+  const res = await requestPublicApiWithoutKey<ApiResponse<unknown>>('health', {
+    method: 'GET',
+  });
+
+  logResponse(res.res, res.body, res.text);
+
+  assert(res.res.status === 401, 'Missing API key should return 401');
+  assert(res.body?.ok === false, 'Missing API key should return ok=false');
+  assert(
+    res.body.error.code === 'AUTH_UNAUTHORIZED',
+    'Missing API key should return AUTH_UNAUTHORIZED',
+  );
+}
+
+async function testRejectsInvalidApiKey(): Promise<void> {
+  logStep('public API rejects requests with an invalid x-api-key');
+
+  const res = await request<ApiResponse<unknown>>('public-api/health', {
+    method: 'GET',
+    headers: {
+      'x-api-key': 'definitely-invalid-public-api-key',
+    },
+  });
+
+  logResponse(res.res, res.body, res.text);
+
+  assert(res.res.status === 401, 'Invalid API key should return 401');
+  assert(res.body?.ok === false, 'Invalid API key should return ok=false');
+  assert(
+    res.body.error.code === 'AUTH_UNAUTHORIZED',
+    'Invalid API key should return AUTH_UNAUTHORIZED',
+  );
+}
+
+async function testHealth(): Promise<void> {
+  logStep('public API health succeeds');
+
+  const res = await requestPublicApi<ApiResponse<PublicApiHealthOk>>('health', {
+    method: 'GET',
+  });
+
+  logResponse(res.res, res.body, res.text);
+
+  assert(res.res.status === 200, 'Public API health should return 200');
+  assert(res.body?.ok === true, 'Public API health should return ok=true');
+  assert(res.body.data.database === 'up', 'Public API health should report database=up');
+  assert(res.body.data.redis === 'up', 'Public API health should report redis=up');
+}
+
+async function testListUsers(): Promise<void> {
+  logStep('public API lists users');
+
+  const res = await requestPublicApi<ApiResponse<UsersListOk>>('users?limit=5&offset=0', {
+    method: 'GET',
+  });
+
+  logResponse(res.res, res.body, res.text);
+
+  assert(res.res.status === 200, 'Public API users list should return 200');
+  assert(res.body?.ok === true, 'Public API users list should return ok=true');
+  assert(res.body.data.meta.limit === 5, 'Users list should echo limit=5');
+  assert(res.body.data.meta.offset === 0, 'Users list should echo offset=0');
+  assert(res.body.data.users.length > 0, 'Users list should return at least one user');
+  assert(
+    res.body.data.users.length <= 5,
+    'Users list should not return more users than the requested limit',
+  );
+  assert(
+    res.body.data.meta.count === res.body.data.users.length,
+    'Users list meta.count should match the number of returned users',
+  );
+}
+
+async function testCountUsers(): Promise<void> {
+  logStep('public API returns user count');
+
+  const res = await requestPublicApi<ApiResponse<PublicUsersCountOk>>('users/count', {
+    method: 'GET',
+  });
+
+  logResponse(res.res, res.body, res.text);
+
+  assert(res.res.status === 200, 'Public API users count should return 200');
+  assert(res.body?.ok === true, 'Public API users count should return ok=true');
+  assert(res.body.data.totalUsers > 0, 'Public API users count should be greater than zero');
+}
+
+async function testSearchUsers(): Promise<void> {
+  logStep('public API searches users');
+
+  const res = await requestPublicApi<ApiResponse<PublicUsersSearchOk>>(
+    `users/search?q=${encodeURIComponent(SEARCH_QUERY)}&limit=5`,
+    {
+      method: 'GET',
+    },
+  );
+
+  logResponse(res.res, res.body, res.text);
+
+  assert(res.res.status === 200, 'Public API users search should return 200');
+  assert(res.body?.ok === true, 'Public API users search should return ok=true');
+  assert(res.body.data.meta.q === SEARCH_QUERY, 'Users search should echo the query string');
+  assert(res.body.data.meta.limit === 5, 'Users search should echo limit=5');
+  assert(
+    res.body.data.users.some((user) => user.username === SEEDED_USERNAME),
+    `Users search should include ${SEEDED_USERNAME}`,
+  );
+}
+
+async function testGetUserByUsernameAndId(): Promise<void> {
+  logStep('public API gets a user by username and id');
+
+  const byUsername = await requestPublicApi<ApiResponse<UserPublic>>(
+    `users/username/${encodeURIComponent(SEEDED_USERNAME)}`,
+    {
+      method: 'GET',
+    },
+  );
+
+  logResponse(byUsername.res, byUsername.body, byUsername.text);
+
+  assert(byUsername.res.status === 200, 'Public API user by username should return 200');
+  assert(byUsername.body?.ok === true, 'Public API user by username should return ok=true');
+  assert(
+    byUsername.body.data.username === SEEDED_USERNAME,
+    `Username lookup should return ${SEEDED_USERNAME}`,
+  );
+
+  const byId = await requestPublicApi<ApiResponse<UserPublic>>(
+    `users/${encodeURIComponent(byUsername.body.data.id)}`,
+    {
+      method: 'GET',
+    },
+  );
+
+  logResponse(byId.res, byId.body, byId.text);
+
+  assert(byId.res.status === 200, 'Public API user by id should return 200');
+  assert(byId.body?.ok === true, 'Public API user by id should return ok=true');
+  assert(byId.body.data.id === byUsername.body.data.id, 'User id lookup should match username id');
+  assert(
+    byId.body.data.username === SEEDED_USERNAME,
+    `User id lookup should resolve to ${SEEDED_USERNAME}`,
+  );
+}
+
+async function main(): Promise<void> {
+  console.log('public API smoke suite starting');
+  console.log('BASE_URL:', BASE_URL);
+  console.log('SEEDED_USERNAME:', SEEDED_USERNAME);
+  console.log('SEARCH_QUERY:', SEARCH_QUERY);
+
+  requirePublicApiKey();
+
+  await runTest(results, 'rejects missing API key', testRejectsMissingApiKey);
+  await runTest(results, 'rejects invalid API key', testRejectsInvalidApiKey);
+  await runTest(results, 'health', testHealth);
+  await runTest(results, 'users list', testListUsers);
+  await runTest(results, 'users count', testCountUsers);
+  await runTest(results, 'users search', testSearchUsers);
+  await runTest(results, 'get user by username and id', testGetUserByUsernameAndId);
+
+  printSummary(results);
+
+  const hasFailures = results.some((result) => !result.ok);
+  if (hasFailures) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error('\nPublic API smoke suite crashed');
+  console.error(error);
+  process.exit(1);
+});

--- a/containers/backend/app/scripts/smoke/smoke.request.ts
+++ b/containers/backend/app/scripts/smoke/smoke.request.ts
@@ -15,12 +15,19 @@ export async function request<T>(
   if (cookies) headers.set('Cookie', cookies);
 
   const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  const url = `${BASE_URL}${normalizedPath}`;
 
-  const res = await fetch(`${BASE_URL}${normalizedPath}`, {
-    ...init,
-    headers,
-    redirect: 'manual',
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      ...init,
+      headers,
+      redirect: 'manual',
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`fetch failed for ${url}: ${message}`);
+  }
 
   storeCookies(res);
 

--- a/containers/backend/app/src/app.ts
+++ b/containers/backend/app/src/app.ts
@@ -16,6 +16,7 @@ import {
   handleInternalDirectMessageSend,
 } from './direct-messages/direct-messages.internal';
 import { authIpRateLimit } from './auth/auth.rate-limit';
+import { publicApiRouter } from './public-api/public-api.routes';
 
 // Ensure required environment variables are set
 // TODO manage like in frontend with a env schema validator
@@ -63,6 +64,7 @@ app.get('/health', async (_req, res) => {
     res.status(500).json({ ok: false });
   }
 });
+app.use('/public-api', publicApiRouter);
 app.use('/users', usersRouter);
 app.use('/auth', authIpRateLimit, authRouter);
 app.use('/protected', protectedRouter);

--- a/containers/backend/app/src/app.ts
+++ b/containers/backend/app/src/app.ts
@@ -23,6 +23,9 @@ import { publicApiRouter } from './public-api/public-api.routes';
 const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) throw new Error('SESSION_SECRET is required');
 
+const publicApiKey = process.env.PUBLIC_API_KEY?.trim();
+if (!publicApiKey) throw new Error('PUBLIC_API_KEY is required');
+
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 const SEVEN_DAYS_MS = ONE_DAY_MS * 7;
 

--- a/containers/backend/app/src/public-api/public-api.controller.ts
+++ b/containers/backend/app/src/public-api/public-api.controller.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from 'express';
+
+import type {
+  PublicApiHealthResponse,
+  PublicUsersCountResponse,
+  PublicUsersSearchResponse,
+} from '@contracts/public-api/public-api.contracts';
+import type { SearchUsersQuery } from '@contracts/users/users.validation';
+import { getRedisClient } from '@shared';
+
+import { prisma } from '../lib/prisma';
+import { countPublicUsers, searchPublicUsers } from '../users/users.service';
+
+export async function getPublicApiHealthController(
+  _req: Request,
+  res: Response<PublicApiHealthResponse>,
+): Promise<void> {
+  await Promise.all([getRedisClient().ping(), prisma.$queryRaw`SELECT 1`]);
+
+  res.status(200).json({
+    ok: true,
+    data: {
+      database: 'up',
+      redis: 'up',
+    },
+  });
+}
+
+export async function getPublicUsersCountController(
+  _req: Request,
+  res: Response<PublicUsersCountResponse>,
+): Promise<void> {
+  const totalUsers = await countPublicUsers();
+
+  res.status(200).json({
+    ok: true,
+    data: {
+      totalUsers,
+    },
+  });
+}
+
+export async function searchPublicUsersController(
+  _req: Request,
+  res: Response<PublicUsersSearchResponse, { query: SearchUsersQuery }>,
+): Promise<void> {
+  const { q, limit } = res.locals.query;
+  const users = await searchPublicUsers(q, limit);
+
+  res.status(200).json({
+    ok: true,
+    data: {
+      users,
+      meta: {
+        q,
+        limit,
+        count: users.length,
+      },
+    },
+  });
+}

--- a/containers/backend/app/src/public-api/public-api.rate-limit.ts
+++ b/containers/backend/app/src/public-api/public-api.rate-limit.ts
@@ -1,0 +1,40 @@
+import type { Request } from 'express';
+
+import { ApiError, readApiKey } from '@shared';
+import { createRateLimit } from '@shared/rate-limit';
+
+const PUBLIC_API_RATE_LIMIT_KEYS = {
+  requests: 'rl:public-api:requests',
+  search: 'rl:public-api:search',
+} as const;
+
+function getPublicApiClientFingerprint(req: Request): string | undefined {
+  const apiKey = readApiKey(req);
+  if (!apiKey) return undefined;
+
+  const ip = req.ip || req.socket.remoteAddress || 'unknown';
+  const normalizedIp = ip.startsWith('::ffff:') ? ip.slice(7) : ip;
+
+  return `${apiKey}:${normalizedIp}`;
+}
+
+function readPositiveNumber(raw: string | undefined, fallback: number): number {
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export const publicApiRateLimit = createRateLimit({
+  keyPrefix: PUBLIC_API_RATE_LIMIT_KEYS.requests,
+  max: readPositiveNumber(process.env.PUBLIC_API_RATE_LIMIT_MAX, 120),
+  windowMs: readPositiveNumber(process.env.PUBLIC_API_RATE_LIMIT_WINDOW_MS, 60_000),
+  extractRaw: getPublicApiClientFingerprint,
+  onLimitExceeded: () => new ApiError('AUTH_RATE_LIMITED'),
+});
+
+export const publicApiSearchRateLimit = createRateLimit({
+  keyPrefix: PUBLIC_API_RATE_LIMIT_KEYS.search,
+  max: readPositiveNumber(process.env.PUBLIC_API_SEARCH_RATE_LIMIT_MAX, 30),
+  windowMs: readPositiveNumber(process.env.PUBLIC_API_SEARCH_RATE_LIMIT_WINDOW_MS, 60_000),
+  extractRaw: getPublicApiClientFingerprint,
+  onLimitExceeded: () => new ApiError('AUTH_RATE_LIMITED'),
+});

--- a/containers/backend/app/src/public-api/public-api.rate-limit.ts
+++ b/containers/backend/app/src/public-api/public-api.rate-limit.ts
@@ -2,6 +2,7 @@ import type { Request } from 'express';
 
 import { ApiError, readApiKey } from '@shared';
 import { createRateLimit } from '@shared/rate-limit';
+import { extractRateLimitIp } from '../auth/auth.rate-limit';
 
 const PUBLIC_API_RATE_LIMIT_KEYS = {
   requests: 'rl:public-api:requests',
@@ -12,10 +13,7 @@ function getPublicApiClientFingerprint(req: Request): string | undefined {
   const apiKey = readApiKey(req);
   if (!apiKey) return undefined;
 
-  const ip = req.ip || req.socket.remoteAddress || 'unknown';
-  const normalizedIp = ip.startsWith('::ffff:') ? ip.slice(7) : ip;
-
-  return `${apiKey}:${normalizedIp}`;
+  return `${apiKey}:${extractRateLimitIp(req)}`;
 }
 
 function readPositiveNumber(raw: string | undefined, fallback: number): number {

--- a/containers/backend/app/src/public-api/public-api.routes.ts
+++ b/containers/backend/app/src/public-api/public-api.routes.ts
@@ -1,6 +1,10 @@
 import { Router } from 'express';
 
-import { GetUserByIdParamSchema, GetUsersQuerySchema, SearchUsersQuerySchema } from '@contracts/users/users.validation';
+import {
+  GetUserByIdParamSchema,
+  GetUsersQuerySchema,
+  SearchUsersQuerySchema,
+} from '@contracts/users/users.validation';
 import { requireApiKey, validateParams, validateQuery } from '@shared';
 
 import { getUserById, getUserByUsername, getUsersController } from '../users/users.controllers';
@@ -13,7 +17,7 @@ import { publicApiRateLimit, publicApiSearchRateLimit } from './public-api.rate-
 
 export const publicApiRouter = Router();
 
-publicApiRouter.use(requireApiKey, publicApiRateLimit);
+publicApiRouter.use(publicApiRateLimit, requireApiKey);
 
 publicApiRouter.get('/health', getPublicApiHealthController);
 publicApiRouter.get('/users', validateQuery(GetUsersQuerySchema), getUsersController);

--- a/containers/backend/app/src/public-api/public-api.routes.ts
+++ b/containers/backend/app/src/public-api/public-api.routes.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+
+import { GetUserByIdParamSchema, GetUsersQuerySchema, SearchUsersQuerySchema } from '@contracts/users/users.validation';
+import { requireApiKey, validateParams, validateQuery } from '@shared';
+
+import { getUserById, getUserByUsername, getUsersController } from '../users/users.controllers';
+import {
+  getPublicApiHealthController,
+  getPublicUsersCountController,
+  searchPublicUsersController,
+} from './public-api.controller';
+import { publicApiRateLimit, publicApiSearchRateLimit } from './public-api.rate-limit';
+
+export const publicApiRouter = Router();
+
+publicApiRouter.use(requireApiKey, publicApiRateLimit);
+
+publicApiRouter.get('/health', getPublicApiHealthController);
+publicApiRouter.get('/users', validateQuery(GetUsersQuerySchema), getUsersController);
+publicApiRouter.get('/users/count', getPublicUsersCountController);
+publicApiRouter.get(
+  '/users/search',
+  publicApiSearchRateLimit,
+  validateQuery(SearchUsersQuerySchema),
+  searchPublicUsersController,
+);
+publicApiRouter.get('/users/username/:username', getUserByUsername);
+publicApiRouter.get('/users/:userId', validateParams(GetUserByIdParamSchema), getUserById);

--- a/containers/backend/app/src/shared/api-key.middleware.ts
+++ b/containers/backend/app/src/shared/api-key.middleware.ts
@@ -13,10 +13,9 @@ export function readApiKey(req: Request): string | undefined {
 }
 
 function matchesApiKey(providedApiKey: string, expectedApiKey: string): boolean {
+  if (providedApiKey.length !== expectedApiKey.length) return false;
   const providedBuffer = Buffer.from(providedApiKey);
   const expectedBuffer = Buffer.from(expectedApiKey);
-
-  if (providedBuffer.length !== expectedBuffer.length) return false;
 
   return timingSafeEqual(providedBuffer, expectedBuffer);
 }

--- a/containers/backend/app/src/shared/api-key.middleware.ts
+++ b/containers/backend/app/src/shared/api-key.middleware.ts
@@ -1,0 +1,39 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+
+import { sendError } from './errors.middleware';
+
+export function readApiKey(req: Request): string | undefined {
+  const apiKey = req.header('x-api-key');
+
+  if (!apiKey) return undefined;
+
+  const normalized = apiKey.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function matchesApiKey(providedApiKey: string, expectedApiKey: string): boolean {
+  const providedBuffer = Buffer.from(providedApiKey);
+  const expectedBuffer = Buffer.from(expectedApiKey);
+
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+export function requireApiKey(req: Request, res: Response, next: NextFunction) {
+  const expectedApiKey = process.env.PUBLIC_API_KEY;
+
+  if (!expectedApiKey) {
+    console.error('PUBLIC_API_KEY is not configured');
+    return sendError(res, 'INTERNAL_ERROR');
+  }
+
+  const providedApiKey = readApiKey(req);
+
+  if (!providedApiKey || !matchesApiKey(providedApiKey, expectedApiKey)) {
+    return sendError(res, 'AUTH_UNAUTHORIZED');
+  }
+
+  next();
+}

--- a/containers/backend/app/src/shared/index.ts
+++ b/containers/backend/app/src/shared/index.ts
@@ -3,6 +3,7 @@ export { validateBody, validateQuery, validateParams } from './validation.middle
 export { ApiError, sendError, errorMiddleware, errorStatus } from './errors.middleware';
 
 export { requireAuth } from './auth.middleware';
+export { requireApiKey, readApiKey } from './api-key.middleware';
 
 export { pool } from './db.pool';
 

--- a/containers/backend/app/src/users/users.repo.ts
+++ b/containers/backend/app/src/users/users.repo.ts
@@ -62,6 +62,10 @@ export async function listUsers(limit: number, offset: number): Promise<UserPubl
   return rows.map(mapUserRow);
 }
 
+export async function countUsers(): Promise<number> {
+  return prisma.user.count();
+}
+
 export async function selectUserData(id: string): Promise<UserPublic | null> {
   const row = await prisma.user.findUnique({
     where: { id },
@@ -108,4 +112,25 @@ export async function searchUsersByUsername(
   `;
 
   return rows;
+}
+
+export async function searchPublicUsersByUsername(
+  query: string,
+  limit: number,
+): Promise<UserPublic[]> {
+  const rows = await prisma.user.findMany({
+    where: {
+      username: {
+        contains: query,
+        mode: 'insensitive',
+      },
+    },
+    orderBy: {
+      username: 'asc',
+    },
+    take: limit,
+    select: userPublicSelect,
+  });
+
+  return rows.map(mapUserRow);
 }

--- a/containers/backend/app/src/users/users.service.ts
+++ b/containers/backend/app/src/users/users.service.ts
@@ -2,7 +2,9 @@ import type { UserMeProfile, UserPublic, SearchUserResult } from '@contracts/use
 import { ApiError } from '@shared';
 
 import {
+  countUsers,
   listUsers,
+  searchPublicUsersByUsername,
   selectUserData,
   selectUserDataByUsername,
   selectUserMeProfileData,
@@ -19,6 +21,10 @@ export async function getUsers(args: getUsersProps): Promise<UserPublic[]> {
   const { limit, offset } = args;
   const data = await listUsers(limit, offset);
   return data;
+}
+
+export async function countPublicUsers(): Promise<number> {
+  return countUsers();
 }
 
 export async function findUserById(id: string): Promise<UserPublic> {
@@ -62,4 +68,8 @@ export async function searchUsers(
       friendshipId: friendship ? friendship.id : null,
     };
   });
+}
+
+export async function searchPublicUsers(query: string, limit: number): Promise<UserPublic[]> {
+  return searchPublicUsersByUsername(query, limit);
 }

--- a/containers/backend/docker/.env.demo.example
+++ b/containers/backend/docker/.env.demo.example
@@ -10,6 +10,7 @@ PGDATABASE=app
 # Sessions (connect-redis; compose sets REDIS_URL by default)
 # -----------------------------
 SESSION_SECRET=change-me
+PUBLIC_API_KEY=change-me
 SESSION_TTL=604800000
 REDIS_URL=redis://redis:6379
 REDIS_HOST=redis

--- a/containers/backend/docker/.env.development.example
+++ b/containers/backend/docker/.env.development.example
@@ -10,6 +10,7 @@ PGDATABASE=app
 # Sessions (connect-redis; compose sets REDIS_URL by default)
 # -----------------------------
 SESSION_SECRET=change-me
+PUBLIC_API_KEY=change-me
 SESSION_TTL=604800000
 REDIS_URL=redis://redis:6379
 REDIS_HOST=redis

--- a/containers/backend/docker/.env.production.example
+++ b/containers/backend/docker/.env.production.example
@@ -10,6 +10,7 @@ PGDATABASE=app
 # Sessions (connect-redis; compose sets REDIS_URL by default)
 # -----------------------------
 SESSION_SECRET=change-me
+PUBLIC_API_KEY=change-me
 SESSION_TTL=604800000
 REDIS_URL=redis://redis:6379
 REDIS_HOST=redis

--- a/containers/backend/docker/.env.test
+++ b/containers/backend/docker/.env.test
@@ -3,6 +3,7 @@ PGPASSWORD=change-me
 PGDATABASE=app_test
 PGHOST=postgres
 SESSION_SECRET=test-session-secret-change-me
+PUBLIC_API_KEY=test-public-api-key-change-me
 GOOGLE_CLIENT_ID=whatever-you-want
 GOOGLE_CLIENT_SECRET=whatever-you-want
 SOCKET_INTERNAL_SECRET=

--- a/containers/contracts/api/public-api/public-api.contracts.ts
+++ b/containers/contracts/api/public-api/public-api.contracts.ts
@@ -1,0 +1,41 @@
+import type { ApiResponse } from '../http/response';
+import type { ValidationErrorDetails } from '../http/validation';
+import type { UserPublic } from '../users/users.contracts';
+import type { UsersErrorName } from '../users/users.errors';
+
+export type PublicApiHealthOk = {
+  database: 'up';
+  redis: 'up';
+};
+
+export type PublicApiHealthResponse = ApiResponse<PublicApiHealthOk, 'INTERNAL_ERROR'>;
+
+export type PublicUsersCountOk = {
+  totalUsers: number;
+};
+
+export type PublicUsersCountResponse = ApiResponse<PublicUsersCountOk, 'INTERNAL_ERROR'>;
+
+export type PublicUsersSearchOk = {
+  users: UserPublic[];
+  meta: {
+    q: string;
+    limit: number;
+    count: number;
+  };
+};
+
+export const PUBLIC_USERS_SEARCH_ERRORS = [
+  'INTERNAL_ERROR',
+  'VALIDATION_ERROR',
+  'AUTH_UNAUTHORIZED',
+  'AUTH_RATE_LIMITED',
+] as const satisfies readonly UsersErrorName[];
+
+export type PublicUsersSearchError = (typeof PUBLIC_USERS_SEARCH_ERRORS)[number];
+
+export type PublicUsersSearchResponse = ApiResponse<
+  PublicUsersSearchOk,
+  PublicUsersSearchError,
+  ValidationErrorDetails
+>;

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -1,21 +1,7 @@
 events {}
 
 http {
-
-  upstream next_upstream {
-    server frontend:3000;
-    keepalive 32;
-  }
-
-  upstream backend_upstream {
-    server backend:4000;
-    keepalive 16;
-  }
-
-  upstream socket_upstream {
-    server socket:3100;
-    keepalive 16;
-  }
+  resolver 127.0.0.11 valid=10s ipv6=off;
   
   limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=100r/m;
 
@@ -40,24 +26,26 @@ http {
       limit_req zone=auth_limit burst=2 nodelay;
       limit_req_status 429;
 
+      set $backend_upstream https://backend:4000;
       rewrite ^/api/(.*)$ /$1 break;
       proxy_ssl_server_name on;
       proxy_ssl_name backend;
       proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
       proxy_ssl_verify on;
       proxy_ssl_verify_depth 1;
-      proxy_pass https://backend_upstream;
+      proxy_pass $backend_upstream;
       proxy_read_timeout 30s;
     }
 
     location ^~ /api/ {
+      set $backend_upstream https://backend:4000;
       rewrite ^/api/(.*)$ /$1 break;
       proxy_ssl_server_name on;
       proxy_ssl_name backend;
       proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
       proxy_ssl_verify on;
       proxy_ssl_verify_depth 1;
-      proxy_pass https://backend_upstream;
+      proxy_pass $backend_upstream;
       proxy_read_timeout 30s;
     }
 
@@ -70,12 +58,13 @@ http {
       proxy_read_timeout 1h;
       proxy_send_timeout 1h;
 
+      set $socket_upstream https://socket:3100;
       proxy_ssl_server_name on;
       proxy_ssl_name socket;
       proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
       proxy_ssl_verify on;
       proxy_ssl_verify_depth 1;
-      proxy_pass https://socket_upstream;
+      proxy_pass $socket_upstream;
     }
 
     location / {
@@ -95,12 +84,13 @@ http {
       proxy_set_header X-Forwarded-Port  $server_port;
       proxy_set_header Origin            $http_origin;
 
+      set $next_upstream https://frontend:3000;
       proxy_ssl_server_name on;
       proxy_ssl_name frontend;
       proxy_ssl_trusted_certificate /etc/nginx/certs/ca.pem;
       proxy_ssl_verify on;
       proxy_ssl_verify_depth 1;
-      proxy_pass https://next_upstream;
+      proxy_pass $next_upstream;
     }
   }
 }

--- a/scripts/env/README.md
+++ b/scripts/env/README.md
@@ -16,6 +16,8 @@ The socket service reads `SOCKET_CORS_ORIGINS` at runtime from Docker Compose. T
 
 `setup-env.sh` generates a dedicated `containers/socket/docker/.env.<env>` file. Only shared variables are synchronized between services: currently `SOCKET_INTERNAL_SECRET` is generated once and written to both backend and socket env files.
 
+For backend secrets, `setup-env.sh` also generates secure random values when missing. This now includes both `SESSION_SECRET` and `PUBLIC_API_KEY`.
+
 ## Template files
 
 Tracked example templates live next to the generated files as `*.example` files. Update those templates when a new variable is added so the local setup stays reproducible without committing secrets.

--- a/scripts/env/setup-env.sh
+++ b/scripts/env/setup-env.sh
@@ -190,6 +190,12 @@ if [ -z "$current_session_secret" ]; then
   set_env_var "$BACKEND_ENV" "SESSION_SECRET" "$SESSION_SECRET"
 fi
 
+current_public_api_key="$(get_env_value "$BACKEND_ENV" "PUBLIC_API_KEY")"
+if [ -z "$current_public_api_key" ]; then
+  PUBLIC_API_KEY=$(openssl rand -hex 32)
+  set_env_var "$BACKEND_ENV" "PUBLIC_API_KEY" "$PUBLIC_API_KEY"
+fi
+
 set_env_var "$BACKEND_ENV" "SESSION_TTL" "604800000"
 
 current_socket_secret="$(get_env_value "$BACKEND_ENV" "SOCKET_INTERNAL_SECRET")"

--- a/scripts/smoke-public-api.sh
+++ b/scripts/smoke-public-api.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_ENV="${1:-development}"
+HOST_CA_CERTS="${HOST_NODE_EXTRA_CA_CERTS:-$ROOT_DIR/certs/ca.pem}"
+HOST_BASE_URL="${BASE_URL:-https://localhost:8443/api/}"
+
+case "$APP_ENV" in
+  development)
+    TARGET_SCRIPT="smoke:public-api:host:dev"
+    ;;
+  test)
+    TARGET_SCRIPT="smoke:public-api:host:test"
+    ;;
+  *)
+    echo "Usage: $0 [development|test]" >&2
+    exit 1
+    ;;
+esac
+
+cd "$ROOT_DIR/containers/backend/app"
+BASE_URL="$HOST_BASE_URL" HOST_NODE_EXTRA_CA_CERTS="$HOST_CA_CERTS" npm run "$TARGET_SCRIPT"


### PR DESCRIPTION
- Introduced a new public API under `/public-api` with endpoints for health checks, user listing, user count, user search, and user retrieval by username or ID.
- Implemented API key authentication for the public API, with rate limiting for requests.
- Added OpenAPI documentation for the new public API endpoints.
- Created smoke tests for the public API to ensure functionality and error handling.
- Updated environment setup scripts to include `PUBLIC_API_KEY` generation.
- Enhanced README documentation to include details about the public API and its usage.