### PR TITLE
feat: enhance direct messaging with unread message tracking

### DIFF
--- a/containers/backend/app/prisma/schema.prisma
+++ b/containers/backend/app/prisma/schema.prisma
@@ -70,6 +70,7 @@ model DirectMessage {
   friendshipId String     @map("friendship_id") @db.Uuid
   senderId     String     @map("sender_id") @db.Uuid
   body         String     @db.VarChar(300)
+  readAt       DateTime?  @map("read_at") @db.Timestamptz(6)
   createdAt    DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
 
   friendship Friendship @relation(fields: [friendshipId], references: [id], onDelete: Cascade)

--- a/containers/backend/app/src/app.ts
+++ b/containers/backend/app/src/app.ts
@@ -13,6 +13,7 @@ import { friendsRouter } from './friendships/friendships.routes';
 import { handleInternalFriendsList } from './friendships/friendships.presence';
 import {
   handleInternalDirectMessageHistory,
+  handleInternalDirectMessageRead,
   handleInternalDirectMessageSend,
 } from './direct-messages/direct-messages.internal';
 import { authIpRateLimit } from './auth/auth.rate-limit';
@@ -75,6 +76,7 @@ app.use('/friends', friendsRouter);
 
 app.post('/internal/friends', handleInternalFriendsList);
 app.post('/internal/direct-messages/history', handleInternalDirectMessageHistory);
+app.post('/internal/direct-messages/read', handleInternalDirectMessageRead);
 app.post('/internal/direct-messages/send', handleInternalDirectMessageSend);
 
 app.use(errorMiddleware);

--- a/containers/backend/app/src/direct-messages/direct-messages.internal.ts
+++ b/containers/backend/app/src/direct-messages/direct-messages.internal.ts
@@ -1,12 +1,17 @@
 import type { Request, Response } from 'express';
-
+import type { DirectMessage, DirectMessageRead } from '@contracts/sockets/direct-messages/direct-messages.schema';
 import {
   DirectMessageSendBodySchema,
   DirectMessageThreadBodySchema,
 } from '@contracts/sockets/direct-messages/direct-messages.schema';
 
 import { findFriendshipByPair } from '../friendships/friendships.repo';
-import { createDirectMessage, listDirectMessagesForFriendship } from './direct-messages.repo';
+import {
+  countUnreadDirectMessagesForFriendship,
+  createDirectMessage,
+  listDirectMessagesForFriendship,
+  markDirectMessagesAsRead,
+} from './direct-messages.repo';
 
 function ensureInternalSecret(req: Request, res: Response): boolean {
   const secret = process.env.SOCKET_INTERNAL_SECRET;
@@ -42,18 +47,20 @@ export function handleInternalDirectMessageHistory(req: Request, res: Response):
       }
 
       const rows = await listDirectMessagesForFriendship(friendship.id);
+      const messages: DirectMessage[] = rows.map((row) => ({
+        id: row.id,
+        createdAt: row.createdAt.getTime(),
+        senderId: row.senderId,
+        username: row.sender.username,
+        readAt: row.readAt?.getTime() ?? null,
+        type: 'user',
+        content: { text: row.body },
+      }));
 
       res.json({
         ok: true,
         data: {
-          messages: rows.map((row) => ({
-            id: row.id,
-            createdAt: row.createdAt.getTime(),
-            senderId: row.senderId,
-            username: row.sender.username,
-            type: 'user' as const,
-            content: { text: row.body },
-          })),
+          messages,
         },
       });
     })
@@ -85,23 +92,67 @@ export function handleInternalDirectMessageSend(req: Request, res: Response): vo
         senderId: parsed.data.currentUserId,
         body: parsed.data.text,
       });
+      const unreadCount = await countUnreadDirectMessagesForFriendship({
+        friendshipId: friendship.id,
+        userId: parsed.data.friendUserId,
+      });
+      const message: DirectMessage = {
+        id: saved.id,
+        createdAt: saved.createdAt.getTime(),
+        senderId: saved.senderId,
+        username: saved.sender.username,
+        readAt: saved.readAt?.getTime() ?? null,
+        type: 'user',
+        content: { text: saved.body },
+      };
 
       res.json({
         ok: true,
         data: {
-          message: {
-            id: saved.id,
-            createdAt: saved.createdAt.getTime(),
-            senderId: saved.senderId,
-            username: saved.sender.username,
-            type: 'user' as const,
-            content: { text: saved.body },
-          },
+          message,
+          unreadCount,
         },
       });
     })
     .catch((error: unknown) => {
       console.error('[direct-messages] failed to save message', error);
+      res.status(500).json({ ok: false });
+    });
+}
+
+export function handleInternalDirectMessageRead(req: Request, res: Response): void {
+  if (!ensureInternalSecret(req, res)) return;
+
+  const parsed = DirectMessageThreadBodySchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    res.status(400).json({ ok: false, errors: parsed.error.flatten() });
+    return;
+  }
+
+  findFriendshipByPair(parsed.data.currentUserId, parsed.data.friendUserId)
+    .then(async (friendship) => {
+      if (!friendship || friendship.status !== 'accepted') {
+        res.status(403).json({ ok: false });
+        return;
+      }
+
+      const unreadCount = await markDirectMessagesAsRead({
+        friendshipId: friendship.id,
+        userId: parsed.data.currentUserId,
+      });
+      const data: DirectMessageRead = {
+        friendUserId: parsed.data.friendUserId,
+        unreadCount,
+      };
+
+      res.json({
+        ok: true,
+        data,
+      });
+    })
+    .catch((error: unknown) => {
+      console.error('[direct-messages] failed to mark thread as read', error);
       res.status(500).json({ ok: false });
     });
 }

--- a/containers/backend/app/src/direct-messages/direct-messages.repo.ts
+++ b/containers/backend/app/src/direct-messages/direct-messages.repo.ts
@@ -4,6 +4,7 @@ export type DirectMessageRow = {
   id: string;
   senderId: string;
   body: string;
+  readAt: Date | null;
   createdAt: Date;
   sender: {
     username: string;
@@ -20,6 +21,7 @@ export async function listDirectMessagesForFriendship(
       id: true,
       senderId: true,
       body: true,
+      readAt: true,
       createdAt: true,
       sender: {
         select: {
@@ -45,6 +47,7 @@ export async function createDirectMessage(args: {
       id: true,
       senderId: true,
       body: true,
+      readAt: true,
       createdAt: true,
       sender: {
         select: {
@@ -53,4 +56,35 @@ export async function createDirectMessage(args: {
       },
     },
   });
+}
+
+export async function countUnreadDirectMessagesForFriendship(args: {
+  friendshipId: string;
+  userId: string;
+}): Promise<number> {
+  return prisma.directMessage.count({
+    where: {
+      friendshipId: args.friendshipId,
+      senderId: { not: args.userId },
+      readAt: null,
+    },
+  });
+}
+
+export async function markDirectMessagesAsRead(args: {
+  friendshipId: string;
+  userId: string;
+}): Promise<number> {
+  await prisma.directMessage.updateMany({
+    where: {
+      friendshipId: args.friendshipId,
+      senderId: { not: args.userId },
+      readAt: null,
+    },
+    data: {
+      readAt: new Date(),
+    },
+  });
+
+  return countUnreadDirectMessagesForFriendship(args);
 }

--- a/containers/backend/app/src/direct-messages/direct-messages.repo.ts
+++ b/containers/backend/app/src/direct-messages/direct-messages.repo.ts
@@ -71,6 +71,29 @@ export async function countUnreadDirectMessagesForFriendship(args: {
   });
 }
 
+export async function countUnreadDirectMessagesByFriendshipIds(args: {
+  friendshipIds: string[];
+  userId: string;
+}): Promise<Map<string, number>> {
+  if (args.friendshipIds.length === 0) return new Map();
+
+  const groupedCounts = await prisma.directMessage.groupBy({
+    by: ['friendshipId'],
+    where: {
+      friendshipId: { in: args.friendshipIds },
+      senderId: { not: args.userId },
+      readAt: null,
+    },
+    _count: {
+      _all: true,
+    },
+  });
+
+  return new Map(
+    groupedCounts.map((row) => [row.friendshipId, row._count._all] as const),
+  );
+}
+
 export async function markDirectMessagesAsRead(args: {
   friendshipId: string;
   userId: string;

--- a/containers/backend/app/src/friendships/friendships.repo.ts
+++ b/containers/backend/app/src/friendships/friendships.repo.ts
@@ -126,7 +126,7 @@ export async function autoAcceptMutualRequest(
 
 export async function listFriendsForUser(
   userId: string,
-): Promise<{ id: string; username: string; avatar: string | null }[]> {
+): Promise<{ id: string; username: string; avatar: string | null; friendshipId: string }[]> {
   const friendships = await prisma.friendship.findMany({
     where: {
       OR: [{ userId1: userId }, { userId2: userId }],
@@ -147,6 +147,7 @@ export async function listFriendsForUser(
       id: friend.id,
       username: friend.username,
       avatar: friend.avatar,
+      friendshipId: f.id,
     };
   });
 }

--- a/containers/backend/app/src/friendships/friendships.service.ts
+++ b/containers/backend/app/src/friendships/friendships.service.ts
@@ -16,7 +16,7 @@ import {
   rejectFriendRequest,
   deleteFriendship,
 } from './friendships.repo';
-import { countUnreadDirectMessagesForFriendship } from '../direct-messages/direct-messages.repo';
+import { countUnreadDirectMessagesByFriendshipIds } from '../direct-messages/direct-messages.repo';
 import {
   notifyFriendAccepted,
   notifyFriendRequest,
@@ -116,20 +116,12 @@ export async function getFriendsList(userId: string): Promise<FriendPublic[]> {
   if (friends.length === 0) return [];
 
   const friendIds = friends.map((friend) => friend.id);
+  const friendshipIds = friends.map((friend) => friend.friendshipId);
   const presenceByUserId = await resolvePresence(friendIds);
-  const unreadByFriendshipId = await Promise.all(
-    friends.map(
-      async (friend) =>
-        [
-          friend.friendshipId,
-          await countUnreadDirectMessagesForFriendship({
-            friendshipId: friend.friendshipId,
-            userId,
-          }),
-        ] as const,
-    ),
-  );
-  const unreadById = new Map(unreadByFriendshipId);
+  const unreadById = await countUnreadDirectMessagesByFriendshipIds({
+    friendshipIds,
+    userId,
+  });
 
   return friends.map((friend) => ({
     id: friend.id,

--- a/containers/backend/app/src/friendships/friendships.service.ts
+++ b/containers/backend/app/src/friendships/friendships.service.ts
@@ -16,6 +16,7 @@ import {
   rejectFriendRequest,
   deleteFriendship,
 } from './friendships.repo';
+import { countUnreadDirectMessagesForFriendship } from '../direct-messages/direct-messages.repo';
 import {
   notifyFriendAccepted,
   notifyFriendRequest,
@@ -116,12 +117,26 @@ export async function getFriendsList(userId: string): Promise<FriendPublic[]> {
 
   const friendIds = friends.map((friend) => friend.id);
   const presenceByUserId = await resolvePresence(friendIds);
+  const unreadByFriendshipId = await Promise.all(
+    friends.map(
+      async (friend) =>
+        [
+          friend.friendshipId,
+          await countUnreadDirectMessagesForFriendship({
+            friendshipId: friend.friendshipId,
+            userId,
+          }),
+        ] as const,
+    ),
+  );
+  const unreadById = new Map(unreadByFriendshipId);
 
   return friends.map((friend) => ({
     id: friend.id,
     username: friend.username,
     avatar: friend.avatar,
     presence: presenceByUserId[friend.id] ?? 'offline',
+    unreadMessageCount: unreadById.get(friend.friendshipId) ?? 0,
   }));
 }
 

--- a/containers/contracts/api/friendships/friendships.contracts.ts
+++ b/containers/contracts/api/friendships/friendships.contracts.ts
@@ -18,6 +18,7 @@ export type FriendPublic = {
   username: string;
   avatar: string | null;
   presence: 'online' | 'away' | 'offline';
+  unreadMessageCount?: number;
 };
 
 export type GetFriendsListOk = { friends: FriendPublic[] };

--- a/containers/contracts/sockets/direct-messages/direct-messages.schema.ts
+++ b/containers/contracts/sockets/direct-messages/direct-messages.schema.ts
@@ -6,6 +6,7 @@ export const directMessageSocketEvents = {
   send: 'dm:send',
   message: 'dm:message',
   history: 'dm:history',
+  read: 'dm:read',
   error: 'dm:error',
 } as const;
 
@@ -44,7 +45,15 @@ const DirectMessageBaseSchema = z.strictObject({
   createdAt: z.number(),
   senderId: z.string().uuid(),
   username: z.string().min(1),
+  readAt: z.number().nullable(),
 });
+
+export const DirectMessageReadSchema = z.strictObject({
+  friendUserId: z.string().uuid(),
+  unreadCount: z.number().int().nonnegative(),
+});
+
+export type DirectMessageRead = z.infer<typeof DirectMessageReadSchema>;
 
 export const DirectMessageSchema = DirectMessageBaseSchema.extend({
   type: z.literal('user'),
@@ -69,10 +78,12 @@ export type DirectMessageError = z.infer<typeof DirectMessageErrorSchema>;
 
 export type ClientToServerDirectMessageEvents = {
   [directMessageSocketEvents.send]: (payload: DirectMessageSend) => void;
+  [directMessageSocketEvents.read]: () => void;
 };
 
 export type ServerToClientDirectMessageEvents = {
   [directMessageSocketEvents.message]: (payload: DirectMessage) => void;
   [directMessageSocketEvents.history]: (payload: DirectMessageHistory) => void;
+  [directMessageSocketEvents.read]: (payload: DirectMessageRead) => void;
   [directMessageSocketEvents.error]: (payload: DirectMessageError) => void;
 };

--- a/containers/contracts/sockets/friendships/friendships.schema.ts
+++ b/containers/contracts/sockets/friendships/friendships.schema.ts
@@ -105,10 +105,9 @@ export type PresenceOfflinePayload = z.infer<typeof PresenceOfflinePayloadSchema
 // Server -> Client events (friendship notifications + presence)
 // ---------------------------------------------------------------------------
 
-type FriendshipEventHandlers = Record<
-  FriendshipSocketEvent,
-  (payload: FriendshipSocketPayloadByEvent[FriendshipSocketEvent]) => void
->;
+type FriendshipEventHandlers = {
+  [K in FriendshipSocketEvent]: (payload: FriendshipSocketPayloadByEvent[K]) => void;
+};
 
 type DirectMessageUnreadEventHandlers = Record<
   DirectMessageUnreadSocketEvent,

--- a/containers/contracts/sockets/friendships/friendships.schema.ts
+++ b/containers/contracts/sockets/friendships/friendships.schema.ts
@@ -6,6 +6,10 @@ export const friendshipSocketEvents = {
   rejected: 'friends:rejected',
 } as const;
 
+export const directMessageUnreadSocketEvents = {
+  updated: 'dm:unread-updated',
+} as const;
+
 export const presenceSocketEvents = {
   online: 'user:online',
   away: 'user:away',
@@ -15,6 +19,9 @@ export const presenceSocketEvents = {
 
 export type FriendshipSocketEvent =
   (typeof friendshipSocketEvents)[keyof typeof friendshipSocketEvents];
+
+export type DirectMessageUnreadSocketEvent =
+  (typeof directMessageUnreadSocketEvents)[keyof typeof directMessageUnreadSocketEvents];
 
 export const friendshipSocketUserIdSchema = z.string().uuid();
 
@@ -46,11 +53,24 @@ export type FriendRejectedNotificationPayload = z.infer<
   typeof FriendRejectedNotificationPayloadSchema
 >;
 
+export const DirectMessageUnreadUpdatedPayloadSchema = z.strictObject({
+  otherUserId: z.string().uuid(),
+  unreadMessageCount: z.number().int().nonnegative(),
+});
+
+export type DirectMessageUnreadUpdatedPayload = z.infer<
+  typeof DirectMessageUnreadUpdatedPayloadSchema
+>;
+
 export const friendshipSocketPayloadSchemas = {
   [friendshipSocketEvents.request]: FriendRequestNotificationPayloadSchema,
   [friendshipSocketEvents.accepted]: FriendAcceptedNotificationPayloadSchema,
   [friendshipSocketEvents.rejected]: FriendRejectedNotificationPayloadSchema,
 } as const satisfies Record<FriendshipSocketEvent, z.ZodTypeAny>;
+
+export const directMessageUnreadSocketPayloadSchemas = {
+  [directMessageUnreadSocketEvents.updated]: DirectMessageUnreadUpdatedPayloadSchema,
+} as const satisfies Record<DirectMessageUnreadSocketEvent, z.ZodTypeAny>;
 
 export type FriendshipSocketPayloadByEvent = {
   [K in keyof typeof friendshipSocketPayloadSchemas]: z.infer<
@@ -85,21 +105,33 @@ export type PresenceOfflinePayload = z.infer<typeof PresenceOfflinePayloadSchema
 // Server -> Client events (friendship notifications + presence)
 // ---------------------------------------------------------------------------
 
-export type ServerToClientFriendshipEvents = {
-  [K in FriendshipSocketEvent]: (payload: FriendshipSocketPayloadByEvent[K]) => void;
-} & {
-  [presenceSocketEvents.online]: (payload: PresenceOnlinePayload) => void;
-  [presenceSocketEvents.away]: (payload: PresenceAwayPayload) => void;
-  [presenceSocketEvents.offline]: (payload: PresenceOfflinePayload) => void;
+type FriendshipEventHandlers = Record<
+  FriendshipSocketEvent,
+  (payload: FriendshipSocketPayloadByEvent[FriendshipSocketEvent]) => void
+>;
+
+type DirectMessageUnreadEventHandlers = Record<
+  DirectMessageUnreadSocketEvent,
+  (payload: DirectMessageUnreadUpdatedPayload) => void
+>;
+
+type PresenceEventHandlers = {
+  'user:online': (payload: PresenceOnlinePayload) => void;
+  'user:away': (payload: PresenceAwayPayload) => void;
+  'user:offline': (payload: PresenceOfflinePayload) => void;
 };
+
+export type ServerToClientFriendshipEvents = FriendshipEventHandlers &
+  DirectMessageUnreadEventHandlers &
+  PresenceEventHandlers;
 
 // ---------------------------------------------------------------------------
 // Client -> Server events (presence signals)
 // ---------------------------------------------------------------------------
 
 export type ClientToServerFriendshipEvents = {
-  [presenceSocketEvents.away]: () => void;
-  [presenceSocketEvents.active]: () => void;
+  'user:away': () => void;
+  'user:active': () => void;
 };
 
 const FriendRequestNotifyBodySchema = z.strictObject({

--- a/containers/frontend/web/src/components/index.ts
+++ b/containers/frontend/web/src/components/index.ts
@@ -57,6 +57,7 @@ export { TooltipTrigger } from './composites/tooltip-trigger';
 
 export { AuthPageLayout, type AuthPageLayoutProps } from './primitives/auth-page-layout';
 export { Avatar, type AvatarProps } from './primitives/avatar';
+export { CountBadge, type CountBadgeProps } from './primitives/count-badge';
 export { Columns12Overlay, Grid4Overlay, Grid8Overlay } from './primitives/base-grid';
 export { GlassCard, type GlassCardProps } from './primitives/glass-card';
 export {

--- a/containers/frontend/web/src/components/primitives/count-badge/count-badge.tsx
+++ b/containers/frontend/web/src/components/primitives/count-badge/count-badge.tsx
@@ -1,0 +1,40 @@
+type CountBadgeTone = 'danger';
+type CountBadgePlacement = 'inline' | 'overlay';
+
+export type CountBadgeProps = {
+  count?: number;
+  max?: number;
+  tone?: CountBadgeTone;
+  placement?: CountBadgePlacement;
+  className?: string;
+};
+
+const toneClassName: Record<CountBadgeTone, string> = {
+  danger: 'bg-rose-500 text-white',
+};
+
+const placementClassName: Record<CountBadgePlacement, string> = {
+  inline: 'inline-flex min-w-5 items-center justify-center rounded-full px-1.5 text-[10px] font-semibold leading-5',
+  overlay:
+    'absolute -end-1 -top-1 inline-flex min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold leading-none',
+};
+
+export function CountBadge({
+  count,
+  max = 99,
+  tone = 'danger',
+  placement = 'inline',
+  className,
+}: CountBadgeProps) {
+  if (typeof count !== 'number' || count <= 0) {
+    return null;
+  }
+
+  const label = count > max ? `${max}+` : String(count);
+
+  return (
+    <span className={`${placementClassName[placement]} ${toneClassName[tone]} ${className ?? ''}`}>
+      {label}
+    </span>
+  );
+}

--- a/containers/frontend/web/src/components/primitives/count-badge/index.ts
+++ b/containers/frontend/web/src/components/primitives/count-badge/index.ts
@@ -1,0 +1,1 @@
+export { CountBadge, type CountBadgeProps } from './count-badge';

--- a/containers/frontend/web/src/features/chat/chat.main.tsx
+++ b/containers/frontend/web/src/features/chat/chat.main.tsx
@@ -4,28 +4,51 @@ import { MessageBubble, ScrollArea, Stack, Text } from '@components';
 import { chatStyles } from './chat.styles';
 import type { ChatMessageUnion } from '@/contracts/sockets/chat/chat.schema';
 
-export function ChatMain({ messages }: { messages: ChatMessageUnion[] }) {
+type ChatMainMessage = ChatMessageUnion & {
+  readAt?: number | null;
+};
+
+export function ChatMain({
+  messages,
+  initialUnreadMessageId,
+}: {
+  messages: ChatMainMessage[];
+  initialUnreadMessageId?: string | null;
+}) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const didScrollToUnreadRef = useRef(false);
 
   useEffect(() => {
+    if (initialUnreadMessageId && !didScrollToUnreadRef.current) {
+      const target = document.getElementById(`message-${initialUnreadMessageId}`);
+
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        didScrollToUnreadRef.current = true;
+        return;
+      }
+    }
+
     if (bottomRef.current) {
       bottomRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages]);
+  }, [initialUnreadMessageId, messages]);
   return (
     <ScrollArea>
       <Stack className={chatStyles.main.wrapper}>
         {messages.map(({ id, username, content, type }) => (
-          <MessageBubble key={id} variant={type}>
-            {type === 'user' && (
-              <Text as="h3" variant="caption">
-                {username}
+          <div key={id} id={`message-${id}`}>
+            <MessageBubble variant={type}>
+              {type === 'user' && (
+                <Text as="h3" variant="caption">
+                  {username}
+                </Text>
+              )}
+              <Text as="p" variant="body-xs" className="whitespace-pre-wrap">
+                {content.text}
               </Text>
-            )}
-            <Text as="p" variant="body-xs" className="whitespace-pre-wrap">
-              {content.text}
-            </Text>
-          </MessageBubble>
+            </MessageBubble>
+          </div>
         ))}
         <div ref={bottomRef} />
       </Stack>

--- a/containers/frontend/web/src/features/direct-messages/direct-messages.tsx
+++ b/containers/frontend/web/src/features/direct-messages/direct-messages.tsx
@@ -17,6 +17,7 @@ import type {
   DirectMessage,
   DirectMessageError,
   DirectMessageHistory,
+  DirectMessageRead,
   DirectMessageSend,
 } from '@/contracts/sockets/direct-messages/direct-messages.schema';
 import { directMessageSocketEvents } from '@/contracts/sockets/direct-messages/direct-messages.schema';
@@ -26,6 +27,7 @@ import { ChatMain } from '@/features/chat/chat.main';
 import { chatStyles } from '@/features/chat/chat.styles';
 import { directMessagesSocket } from '@/lib/sockets/direct-messages-socket.client';
 import { DirectMessagesSocketManager } from '@/lib/sockets/direct-messages-socket.manager';
+import { useSocialStore } from '@/providers/social-provider';
 
 type DirectMessageContextValue = {
   messages: DirectChatHistory;
@@ -39,6 +41,7 @@ const DirectMessageContext = createContext<DirectMessageContextValue | null>(nul
 type DirectChatMessage = ChatMessageUnion & {
   clientMessageId?: string;
   senderId?: string;
+  readAt?: number | null;
 };
 
 type DirectChatHistory = DirectChatMessage[];
@@ -71,6 +74,7 @@ function optimisticDirectMessage(args: {
     username: args.currentUsername,
     type: 'me',
     clientMessageId: args.clientMessageId,
+    readAt: null,
     content: {
       text: args.text,
     },
@@ -160,9 +164,10 @@ function useDirectMessageState(currentUserId: string) {
 
 function DirectMessagesContent({
   friendUsername,
+  initialUnreadMessageId,
 }: {
   friendUsername: string;
-  currentUsername: string;
+  initialUnreadMessageId: string | null;
 }) {
   const t = useTranslations('features.chat');
   const context = useContext(DirectMessageContext);
@@ -176,7 +181,7 @@ function DirectMessagesContent({
   return (
     <Stack gap="none" className={chatStyles.wrapper}>
       <ChatHeader room={friendUsername} participants={[]} />
-      <ChatMain messages={messages} />
+      <ChatMain messages={messages} initialUnreadMessageId={initialUnreadMessageId} />
       <Form
         onSubmit={(event: FormEvent<HTMLFormElement>) => {
           event.preventDefault();
@@ -208,6 +213,7 @@ export function DirectMessagesFeature({
   currentUserId,
   currentUsername,
 }: DirectMessagesFeatureProps) {
+  const setFriendUnreadMessageCount = useSocialStore((state) => state.setFriendUnreadMessageCount);
   const {
     messages,
     value,
@@ -217,6 +223,48 @@ export function DirectMessagesFeature({
     handleDirectHistory,
     handleDirectError,
   } = useDirectMessageState(currentUserId);
+
+  const initialUnreadMessageId = useMemo(
+    () =>
+      messages.find((message) => message.senderId !== currentUserId && message.readAt === null)
+        ?.id ?? null,
+    [currentUserId, messages],
+  );
+
+  const handleDirectRead = useCallback(
+    (payload: DirectMessageRead) => {
+      setFriendUnreadMessageCount(friendUserId, payload.unreadCount);
+    },
+    [friendUserId, setFriendUnreadMessageCount],
+  );
+
+  const requestRead = useCallback(() => {
+    directMessagesSocket.emit(directMessageSocketEvents.read);
+  }, []);
+
+  const handleHistory = useCallback(
+    (history: DirectMessageHistory) => {
+      handleDirectHistory(history);
+
+      if (
+        history.some((message) => message.senderId !== currentUserId && message.readAt === null)
+      ) {
+        requestRead();
+      }
+    },
+    [currentUserId, handleDirectHistory, requestRead],
+  );
+
+  const handleMessage = useCallback(
+    (message: DirectMessage) => {
+      handleDirectMessage(message);
+
+      if (message.senderId !== currentUserId && message.readAt === null) {
+        requestRead();
+      }
+    },
+    [currentUserId, handleDirectMessage, requestRead],
+  );
 
   const sendMessage = useCallback(() => {
     const text = value.trim();
@@ -248,11 +296,15 @@ export function DirectMessagesFeature({
     <DirectMessageContext.Provider value={contextValue}>
       <DirectMessagesSocketManager
         friendUserId={friendUserId}
-        onDirectMessage={handleDirectMessage}
-        onDirectHistory={handleDirectHistory}
+        onDirectMessage={handleMessage}
+        onDirectHistory={handleHistory}
+        onDirectRead={handleDirectRead}
         onDirectError={handleDirectError}
       />
-      <DirectMessagesContent friendUsername={friendUsername} currentUsername={currentUsername} />
+      <DirectMessagesContent
+        friendUsername={friendUsername}
+        initialUnreadMessageId={initialUnreadMessageId}
+      />
     </DirectMessageContext.Provider>
   );
 }

--- a/containers/frontend/web/src/features/direct-messages/messages-layout.tsx
+++ b/containers/frontend/web/src/features/direct-messages/messages-layout.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import type { FriendPublic } from '@/contracts/api/friendships/friendships.contracts';
+import { useSocialStore } from '@/providers/social-provider';
 import { MessagesList } from './messages-list';
 
 type MessagesLayoutProps = {
@@ -11,10 +12,15 @@ type MessagesLayoutProps = {
 };
 
 export function MessagesLayout({ friends, selectedUsername, children }: MessagesLayoutProps) {
+  const liveFriends = useSocialStore((state) => state.friends);
+
   return (
     <div className="pointer-events-auto flex w-full min-w-0 flex-1 h-[100dvh] overflow-hidden">
       <div className="flex min-h-0 w-[400px] shrink-0 overflow-hidden ml-8">
-        <MessagesList friends={friends} selectedUsername={selectedUsername} />
+        <MessagesList
+          friends={liveFriends.length > 0 ? liveFriends : friends}
+          selectedUsername={selectedUsername}
+        />
       </div>
 
       <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>

--- a/containers/frontend/web/src/features/direct-messages/messages-list.tsx
+++ b/containers/frontend/web/src/features/direct-messages/messages-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { Stack, Text, ScrollArea, UserItem } from '@components';
+import { CountBadge, Stack, Text, ScrollArea, UserItem } from '@components';
 import type { FriendPublic } from '@/contracts/api/friendships/friendships.contracts';
 
 type MessagesListProps = {
@@ -40,7 +40,9 @@ export function MessagesList({ friends, selectedUsername }: MessagesListProps) {
                       ? t('presence.away')
                       : t('presence.offline')
                 }
-              />
+              >
+                <CountBadge count={friend.unreadMessageCount} />
+              </UserItem>
             ))
           )}
         </Stack>

--- a/containers/frontend/web/src/features/navigation/navigation-main/navigation-main.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation-main/navigation-main.tsx
@@ -3,12 +3,13 @@
 import { type ReactNode } from 'react';
 import { getPathname } from '@/i18n/navigation';
 import { usePathname } from 'next/navigation';
-import { Icon, NavLink, Stack, TooltipTrigger } from '@components';
+import { CountBadge, Icon, NavLink, Stack, TooltipTrigger } from '@components';
 import { type NavItem } from '../navigation.config';
 import { useTranslations } from 'next-intl';
 import { Logout } from '../../auth/logout';
 import { useNavigationContext } from '../navigation.context';
 import { headerStyles } from '../navigation-header/navigation-header.styles';
+import { useSocialStore } from '@/providers/social-provider';
 
 type NavLinkItemProps = {
   navItem: NavItem;
@@ -22,15 +23,17 @@ type RenderNavLinkContentProps = {
   icon: NavItem['icon'];
   label: string;
   isExpanded: boolean;
+  badgeCount?: number;
 };
 
 export function RenderNavLinkContent(args: RenderNavLinkContentProps) {
-  const { icon, label, isExpanded } = args;
+  const { icon, label, isExpanded, badgeCount } = args;
 
   return (
     <>
-      <div className={headerStyles.wrapper}>
+      <div className={`${headerStyles.wrapper} relative`}>
         <Icon name={icon} size={20} />
+        <CountBadge count={badgeCount} placement="overlay" />
       </div>
       {isExpanded ? <span className="whitespace-nowrap pe-3 leading-none">{label}</span> : null}
     </>
@@ -44,6 +47,9 @@ function WithTooltip(content: ReactNode, label: string, enabled: boolean) {
 function NavLinkItem(args: NavLinkItemProps) {
   const { navItem } = args;
   const { isExpanded, locale, closeNavigation } = useNavigationContext();
+  const unreadTotal = useSocialStore((state) =>
+    state.friends.reduce((sum, friend) => sum + (friend.unreadMessageCount ?? 0), 0),
+  );
 
   const t = useTranslations('features.navigation');
   const label = t(navItem.key);
@@ -64,7 +70,12 @@ function NavLinkItem(args: NavLinkItemProps) {
       w={isExpanded ? 'full' : 'auto'}
       className={navLinkClassName}
     >
-      <RenderNavLinkContent icon={navItem.icon} label={label} isExpanded={isExpanded} />
+      <RenderNavLinkContent
+        icon={navItem.icon}
+        label={label}
+        isExpanded={isExpanded}
+        badgeCount={navItem.href === '/messages' ? unreadTotal : undefined}
+      />
     </NavLink>
   );
 

--- a/containers/frontend/web/src/features/profile/profile-friendship-actions.tsx
+++ b/containers/frontend/web/src/features/profile/profile-friendship-actions.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
-import { Button, DynamicInternalLink, Stack, Text } from '@components';
+import { Button, CountBadge, DynamicInternalLink, Stack, Text } from '@components';
 
 import type { FriendshipAction } from '@/features/social/friendship-actions/friendship-actions.types';
 import type { FriendshipActionKey } from '@/features/social/friendship-actions/friendship-actions.types';
@@ -42,9 +42,12 @@ export function ProfileFriendshipActions({ actions }: ProfileFriendshipActionsPr
               as="button"
               href={action.href}
               variant={variant}
-              className={className}
+              className={`${className ?? ''} relative`}
             >
-              {action.label}
+              <span className="inline-flex items-center gap-2">
+                <span>{action.label}</span>
+                <CountBadge count={action.badgeCount} />
+              </span>
             </DynamicInternalLink>
           );
         }

--- a/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.config.ts
+++ b/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.config.ts
@@ -11,6 +11,7 @@ export function createFriendshipActions({
   t,
   handlers,
   error,
+  unreadMessageCount,
 }: CreateFriendshipActionsArgs): FriendshipAction[] {
   const actionsByStatus: Record<FriendshipStatus, FriendshipAction[]> = {
     friend: [
@@ -19,6 +20,7 @@ export function createFriendshipActions({
         type: 'link',
         label: t('message'),
         href: `/messages/${username ?? userId}`,
+        badgeCount: unreadMessageCount,
       },
       {
         key: 'deleteFriend',

--- a/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.types.ts
+++ b/containers/frontend/web/src/features/social/friendship-actions/friendship-actions.types.ts
@@ -43,6 +43,7 @@ export type FriendshipAction =
       type: 'link';
       label: string;
       href: string;
+      badgeCount?: number;
     }
   | {
       key: FriendshipActionKey;
@@ -59,4 +60,5 @@ export interface CreateFriendshipActionsArgs {
   t: (key: string) => string;
   handlers: FriendshipActionHandlers;
   error?: FriendshipActionError;
+  unreadMessageCount?: number;
 }

--- a/containers/frontend/web/src/features/social/friendship-actions/use-friendship-actions.ts
+++ b/containers/frontend/web/src/features/social/friendship-actions/use-friendship-actions.ts
@@ -52,5 +52,6 @@ export function useFriendshipActions({
     error,
     handlers,
     status: getFriendshipStatus({ friend, requestReceived, requestSent }),
+    unreadMessageCount: friend?.unreadMessageCount,
   });
 }

--- a/containers/frontend/web/src/features/social/social-variants/social-user-actions.tsx
+++ b/containers/frontend/web/src/features/social/social-variants/social-user-actions.tsx
@@ -2,7 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 
-import { DynamicInternalLink, Icon, IconButton } from '@components';
+import { CountBadge, DynamicInternalLink, Icon, IconButton } from '@components';
+import { useSocialStore } from '@/providers/social-provider';
 
 import { SocialFriendshipActions } from './social-friendship-actions';
 import type { UsersListType } from './users-list';
@@ -15,6 +16,9 @@ interface SocialUserActionsProps {
 
 export function SocialUserActions({ type, userId, username }: SocialUserActionsProps) {
   const t = useTranslations('features.social.actions');
+  const unreadMessageCount = useSocialStore(
+    (state) => state.friends.find((friend) => friend.id === userId)?.unreadMessageCount ?? 0,
+  );
   const messageHref = `/messages/${username}` as const;
 
   return (
@@ -24,7 +28,12 @@ export function SocialUserActions({ type, userId, username }: SocialUserActionsP
           as="icon"
           href={messageHref}
           label={t('message')}
-          icon={<Icon name="messages" />}
+          icon={
+            <span className="relative inline-flex">
+              <Icon name="messages" />
+              <CountBadge count={unreadMessageCount} placement="overlay" className="-end-1.5" />
+            </span>
+          }
         />
       )}
 

--- a/containers/frontend/web/src/features/social/store/social-store.bridge.tsx
+++ b/containers/frontend/web/src/features/social/store/social-store.bridge.tsx
@@ -2,6 +2,7 @@
 
 import { SocialSocketManager } from '@/lib/sockets/friends-socket.manager';
 import { useSocialStore } from '@/providers/social-provider';
+import type { DirectMessageUnreadUpdatedPayload } from '@/contracts/sockets/friendships/friendships.schema';
 
 export function SocialSocketBridge() {
   const currentUserId = useSocialStore((state) => state.currentUserId);
@@ -10,6 +11,7 @@ export function SocialSocketBridge() {
   const receiveFriendRequest = useSocialStore((state) => state.receiveFriendRequest);
   const receiveFriendAccepted = useSocialStore((state) => state.receiveFriendAccepted);
   const receiveFriendRejected = useSocialStore((state) => state.receiveFriendRejected);
+  const setFriendUnreadMessageCount = useSocialStore((state) => state.setFriendUnreadMessageCount);
 
   if (!currentUserId) {
     return null;
@@ -23,6 +25,9 @@ export function SocialSocketBridge() {
       onFriendRequest={receiveFriendRequest}
       onFriendAccepted={receiveFriendAccepted}
       onFriendRejected={receiveFriendRejected}
+      onUnreadUpdated={(payload: DirectMessageUnreadUpdatedPayload) =>
+        setFriendUnreadMessageCount(payload.otherUserId, payload.unreadMessageCount)
+      }
     />
   );
 }

--- a/containers/frontend/web/src/features/social/store/social-store.reducers.ts
+++ b/containers/frontend/web/src/features/social/store/social-store.reducers.ts
@@ -142,6 +142,17 @@ function setFriendPresenceReducer(
   });
 }
 
+function setFriendUnreadMessageCountReducer(
+  userId: string,
+  count: number,
+): (state: SocialState) => Partial<SocialState> {
+  return (state) => ({
+    friends: state.friends.map((friend) =>
+      friend.id === userId ? { ...friend, unreadMessageCount: count } : friend,
+    ),
+  });
+}
+
 function receiveFriendRequestReducer(
   payload: FriendRequestNotificationPayload,
 ): (state: SocialState) => Partial<SocialState> {
@@ -406,6 +417,9 @@ export function createSocialActions(set: SetState) {
 
     setFriendPresence: (userId: string, presence: 'online' | 'away' | 'offline') =>
       set(setFriendPresenceReducer(userId, presence)),
+
+    setFriendUnreadMessageCount: (userId: string, count: number) =>
+      set(setFriendUnreadMessageCountReducer(userId, count)),
 
     receiveFriendRequest: (payload: FriendRequestNotificationPayload) =>
       set(receiveFriendRequestReducer(payload)),

--- a/containers/frontend/web/src/features/social/store/social-store.ts
+++ b/containers/frontend/web/src/features/social/store/social-store.ts
@@ -7,6 +7,7 @@ export const createInitialState = (initialData: SocialInitialData) => ({
   friends: initialData.friends.map((f) => ({
     ...f,
     presence: (f as any).presence ?? 'offline',
+    unreadMessageCount: f.unreadMessageCount ?? 0,
   })),
   pendingReceived: initialData.pendingReceived,
   pendingSent: initialData.pendingSent,

--- a/containers/frontend/web/src/features/social/store/social-store.types.tsx
+++ b/containers/frontend/web/src/features/social/store/social-store.types.tsx
@@ -57,6 +57,7 @@ export interface SocialState {
   removeFriendById: (id: string) => void;
   acceptPendingById: (id: string) => void;
   addPendingRequest: (friendship: FriendshipPublic, wasAutoAccepted?: boolean) => void;
+  setFriendUnreadMessageCount: (userId: string, count: number) => void;
 
   /** Preferred: set precise presence */
   setFriendPresence: (userId: string, presence: 'online' | 'away' | 'offline') => void;

--- a/containers/frontend/web/src/lib/sockets/direct-messages-socket.manager.tsx
+++ b/containers/frontend/web/src/lib/sockets/direct-messages-socket.manager.tsx
@@ -8,6 +8,7 @@ import {
   type DirectMessage,
   type DirectMessageError,
   type DirectMessageHistory,
+  type DirectMessageRead,
 } from '@/contracts/sockets/direct-messages/direct-messages.schema';
 
 import { directMessagesSocket } from './direct-messages-socket.client';
@@ -16,6 +17,7 @@ type DirectMessagesSocketManagerProps = {
   friendUserId: string;
   onDirectMessage: (message: DirectMessage) => void;
   onDirectHistory: (history: DirectMessageHistory) => void;
+  onDirectRead: (payload: DirectMessageRead) => void;
   onDirectError: (error: DirectMessageError) => void;
 };
 
@@ -23,6 +25,7 @@ export function DirectMessagesSocketManager({
   friendUserId,
   onDirectMessage,
   onDirectHistory,
+  onDirectRead,
   onDirectError,
 }: DirectMessagesSocketManagerProps) {
   useEffect(() => {
@@ -48,6 +51,11 @@ export function DirectMessagesSocketManager({
       onDirectHistory(history);
     };
 
+    const handleRead = (payload: DirectMessageRead) => {
+      console.log('👀 Received read state:', payload);
+      onDirectRead(payload);
+    };
+
     const handleError = (error: DirectMessageError) => {
       console.error('⚠️ Direct message error:', error);
       onDirectError(error);
@@ -62,6 +70,7 @@ export function DirectMessagesSocketManager({
     const messageListeners = [
       [directMessageSocketEvents.message, handleMessage],
       [directMessageSocketEvents.history, handleHistory],
+      [directMessageSocketEvents.read, handleRead],
       [directMessageSocketEvents.error, handleError],
     ] as const;
 
@@ -87,7 +96,7 @@ export function DirectMessagesSocketManager({
       messageListeners.forEach(([event, handler]) => directMessagesSocket.off(event, handler));
       directMessagesSocket.disconnect();
     };
-  }, [friendUserId, onDirectMessage, onDirectHistory, onDirectError]);
+  }, [friendUserId, onDirectMessage, onDirectHistory, onDirectRead, onDirectError]);
 
   return null;
 }

--- a/containers/frontend/web/src/lib/sockets/friends-socket.manager.ts
+++ b/containers/frontend/web/src/lib/sockets/friends-socket.manager.ts
@@ -3,6 +3,8 @@
 import { useEffect } from 'react';
 
 import {
+  directMessageUnreadSocketEvents,
+  type DirectMessageUnreadUpdatedPayload,
   friendshipSocketEvents,
   presenceSocketEvents,
   type FriendAcceptedNotificationPayload,
@@ -22,6 +24,7 @@ type SocialSocketManagerProps = {
   onFriendRequest: (payload: FriendRequestNotificationPayload) => void;
   onFriendAccepted: (payload: FriendAcceptedNotificationPayload) => void;
   onFriendRejected: (payload: FriendRejectedNotificationPayload) => void;
+  onUnreadUpdated: (payload: DirectMessageUnreadUpdatedPayload) => void;
 };
 
 export const SocialSocketManager = ({
@@ -31,6 +34,7 @@ export const SocialSocketManager = ({
   onFriendRequest,
   onFriendAccepted,
   onFriendRejected,
+  onUnreadUpdated,
 }: SocialSocketManagerProps) => {
   useEffect(() => {
     const emitCurrentPresence = () => {
@@ -74,6 +78,10 @@ export const SocialSocketManager = ({
       onFriendRejected(payload);
     };
 
+    const handleUnreadUpdated = (payload: DirectMessageUnreadUpdatedPayload) => {
+      onUnreadUpdated(payload);
+    };
+
     const reservedListeners = [
       ['connect', handleConnect],
       ['connect_error', handleConnectError],
@@ -90,6 +98,7 @@ export const SocialSocketManager = ({
       [friendshipSocketEvents.request, handleFriendRequest],
       [friendshipSocketEvents.accepted, handleFriendAccepted],
       [friendshipSocketEvents.rejected, handleFriendRejected],
+      [directMessageUnreadSocketEvents.updated, handleUnreadUpdated],
     ] as const;
 
     reservedListeners.forEach(([event, handler]) => {
@@ -132,6 +141,7 @@ export const SocialSocketManager = ({
     onFriendRequest,
     onFriendAccepted,
     onFriendRejected,
+    onUnreadUpdated,
   ]);
 
   return null;

--- a/containers/socket/app/src/features/direct-messages.socket.ts
+++ b/containers/socket/app/src/features/direct-messages.socket.ts
@@ -6,12 +6,18 @@ import {
   DirectMessageSendSchema,
   directMessageFriendUserIdSchema,
   directMessageSocketEvents,
+  type DirectMessageRead,
   type ClientToServerDirectMessageEvents,
   type DirectMessageError,
   type ServerToClientDirectMessageEvents,
 } from '@contracts/sockets/direct-messages/direct-messages.schema';
 
-import { fetchDirectMessageHistory, sendDirectMessage } from '../internal/direct-messages.client';
+import { directMessageUnreadUpdatedSocketEvent, emitToUser } from '../features/friends.socket';
+import {
+  fetchDirectMessageHistory,
+  markDirectMessagesRead,
+  sendDirectMessage,
+} from '../internal/direct-messages.client';
 import { fetchAcceptedFriendIds } from '../internal/friends.client';
 
 function sortedPair(userId1: string, userId2: string): [string, string] {
@@ -34,6 +40,28 @@ function errorMessage(): DirectMessageError {
       text: 'INVALID_DIRECT_MESSAGE',
     },
   };
+}
+
+async function emitReadState(
+  socket: Socket<ClientToServerDirectMessageEvents, ServerToClientDirectMessageEvents>,
+  currentUserId: string,
+  friendUserId: string,
+): Promise<void> {
+  const unreadCount = await markDirectMessagesRead({ currentUserId, friendUserId });
+
+  if (typeof unreadCount !== 'number') return;
+
+  emitToUser(currentUserId, directMessageUnreadUpdatedSocketEvent, {
+    otherUserId: friendUserId,
+    unreadMessageCount: unreadCount,
+  });
+
+  const payload: DirectMessageRead = {
+    friendUserId,
+    unreadCount,
+  };
+
+  socket.emit(directMessageSocketEvents.read, payload);
 }
 
 export function registerDirectMessagesSocket(
@@ -88,10 +116,19 @@ export function registerDirectMessagesSocket(
           return;
         }
 
+        emitToUser(friendUserIdResult.data, directMessageUnreadUpdatedSocketEvent, {
+          otherUserId: currentUserId,
+          unreadMessageCount: saved.unreadCount,
+        });
+
         nsp.to(roomId).emit(directMessageSocketEvents.message, {
-          ...saved,
+          ...saved.message,
           clientMessageId: parsed.data.clientMessageId,
         });
+      });
+
+      socket.on(directMessageSocketEvents.read, async () => {
+        await emitReadState(socket, currentUserId, friendUserIdResult.data);
       });
 
       const historyRows = await fetchDirectMessageHistory({
@@ -100,6 +137,7 @@ export function registerDirectMessagesSocket(
       });
 
       socket.emit(directMessageSocketEvents.history, historyRows);
+      await emitReadState(socket, currentUserId, friendUserIdResult.data);
     },
   );
 }

--- a/containers/socket/app/src/features/direct-messages.socket.ts
+++ b/containers/socket/app/src/features/direct-messages.socket.ts
@@ -11,8 +11,9 @@ import {
   type DirectMessageError,
   type ServerToClientDirectMessageEvents,
 } from '@contracts/sockets/direct-messages/direct-messages.schema';
+import { directMessageUnreadSocketEvents } from '@contracts/sockets/friendships/friendships.schema';
 
-import { directMessageUnreadUpdatedSocketEvent, emitToUser } from '../features/friends.socket';
+import { emitToUser } from '../features/friends.socket';
 import {
   fetchDirectMessageHistory,
   markDirectMessagesRead,
@@ -35,6 +36,7 @@ function errorMessage(): DirectMessageError {
     createdAt: Date.now(),
     senderId: randomUUID(),
     username: 'system',
+    readAt: null,
     type: 'error',
     content: {
       text: 'INVALID_DIRECT_MESSAGE',
@@ -51,7 +53,7 @@ async function emitReadState(
 
   if (typeof unreadCount !== 'number') return;
 
-  emitToUser(currentUserId, directMessageUnreadUpdatedSocketEvent, {
+  emitToUser(currentUserId, directMessageUnreadSocketEvents.updated, {
     otherUserId: friendUserId,
     unreadMessageCount: unreadCount,
   });
@@ -116,7 +118,7 @@ export function registerDirectMessagesSocket(
           return;
         }
 
-        emitToUser(friendUserIdResult.data, directMessageUnreadUpdatedSocketEvent, {
+        emitToUser(friendUserIdResult.data, directMessageUnreadSocketEvents.updated, {
           otherUserId: currentUserId,
           unreadMessageCount: saved.unreadCount,
         });

--- a/containers/socket/app/src/features/friends.socket.ts
+++ b/containers/socket/app/src/features/friends.socket.ts
@@ -1,4 +1,5 @@
 import type { Namespace, Socket } from 'socket.io';
+import { z } from 'zod';
 
 import {
   FriendAcceptedNotificationPayloadSchema,
@@ -14,6 +15,15 @@ import {
 } from '@contracts/sockets/friendships/friendships.schema';
 import { logEvents } from '../socket.logs';
 import { fetchAcceptedFriendIds } from '../internal/friends.client';
+
+export const directMessageUnreadUpdatedSocketEvent = 'dm:unread-updated' as const;
+
+const DirectMessageUnreadUpdatedPayloadSchema = z.strictObject({
+  otherUserId: z.string().uuid(),
+  unreadMessageCount: z.number().int().nonnegative(),
+});
+
+type DirectMessageUnreadUpdatedPayload = z.infer<typeof DirectMessageUnreadUpdatedPayloadSchema>;
 
 let friendsNsp: Namespace<ClientToServerFriendshipEvents, ServerToClientFriendshipEvents> | null =
   null;
@@ -204,8 +214,15 @@ export function emitToUser(
 ): void;
 export function emitToUser(
   userId: string,
-  event: FriendshipSocketEvent,
-  payload: FriendshipSocketPayloadByEvent[FriendshipSocketEvent],
+  event: typeof directMessageUnreadUpdatedSocketEvent,
+  payload: DirectMessageUnreadUpdatedPayload,
+): void;
+export function emitToUser(
+  userId: string,
+  event: FriendshipSocketEvent | typeof directMessageUnreadUpdatedSocketEvent,
+  payload:
+    | FriendshipSocketPayloadByEvent[FriendshipSocketEvent]
+    | DirectMessageUnreadUpdatedPayload,
 ): void {
   const parsedUserId = friendshipSocketUserIdSchema.safeParse(userId);
 
@@ -277,6 +294,26 @@ export function emitToUser(
       friendsNsp
         ?.to(`user:${parsedUserId.data}`)
         .emit(friendshipSocketEvents.rejected, parsedPayload.data);
+      break;
+    }
+
+    case directMessageUnreadUpdatedSocketEvent: {
+      const parsedPayload = DirectMessageUnreadUpdatedPayloadSchema.safeParse(payload);
+
+      if (!parsedPayload.success) {
+        logEvents.error({
+          event: 'friends_socket_emit_validation_failed',
+          socketEvent: event,
+          userId: parsedUserId.data,
+          reason: 'invalid_payload',
+          errors: parsedPayload.error.flatten(),
+        });
+        return;
+      }
+
+      friendsNsp
+        ?.to(`user:${parsedUserId.data}`)
+        .emit(directMessageUnreadUpdatedSocketEvent, parsedPayload.data);
       break;
     }
   }

--- a/containers/socket/app/src/features/friends.socket.ts
+++ b/containers/socket/app/src/features/friends.socket.ts
@@ -1,29 +1,22 @@
 import type { Namespace, Socket } from 'socket.io';
-import { z } from 'zod';
 
 import {
+  DirectMessageUnreadUpdatedPayloadSchema,
   FriendAcceptedNotificationPayloadSchema,
   FriendRejectedNotificationPayloadSchema,
   FriendRequestNotificationPayloadSchema,
+  directMessageUnreadSocketEvents,
   friendshipSocketEvents,
   friendshipSocketUserIdSchema,
   presenceSocketEvents,
   type ClientToServerFriendshipEvents,
+  type DirectMessageUnreadUpdatedPayload,
   type FriendshipSocketEvent,
   type FriendshipSocketPayloadByEvent,
   type ServerToClientFriendshipEvents,
 } from '@contracts/sockets/friendships/friendships.schema';
 import { logEvents } from '../socket.logs';
 import { fetchAcceptedFriendIds } from '../internal/friends.client';
-
-export const directMessageUnreadUpdatedSocketEvent = 'dm:unread-updated' as const;
-
-const DirectMessageUnreadUpdatedPayloadSchema = z.strictObject({
-  otherUserId: z.string().uuid(),
-  unreadMessageCount: z.number().int().nonnegative(),
-});
-
-type DirectMessageUnreadUpdatedPayload = z.infer<typeof DirectMessageUnreadUpdatedPayloadSchema>;
 
 let friendsNsp: Namespace<ClientToServerFriendshipEvents, ServerToClientFriendshipEvents> | null =
   null;
@@ -214,12 +207,12 @@ export function emitToUser(
 ): void;
 export function emitToUser(
   userId: string,
-  event: typeof directMessageUnreadUpdatedSocketEvent,
+  event: typeof directMessageUnreadSocketEvents.updated,
   payload: DirectMessageUnreadUpdatedPayload,
 ): void;
 export function emitToUser(
   userId: string,
-  event: FriendshipSocketEvent | typeof directMessageUnreadUpdatedSocketEvent,
+  event: FriendshipSocketEvent | typeof directMessageUnreadSocketEvents.updated,
   payload:
     | FriendshipSocketPayloadByEvent[FriendshipSocketEvent]
     | DirectMessageUnreadUpdatedPayload,
@@ -297,7 +290,7 @@ export function emitToUser(
       break;
     }
 
-    case directMessageUnreadUpdatedSocketEvent: {
+    case directMessageUnreadSocketEvents.updated: {
       const parsedPayload = DirectMessageUnreadUpdatedPayloadSchema.safeParse(payload);
 
       if (!parsedPayload.success) {
@@ -313,7 +306,7 @@ export function emitToUser(
 
       friendsNsp
         ?.to(`user:${parsedUserId.data}`)
-        .emit(directMessageUnreadUpdatedSocketEvent, parsedPayload.data);
+        .emit(directMessageUnreadSocketEvents.updated, parsedPayload.data);
       break;
     }
   }

--- a/containers/socket/app/src/internal/direct-messages.client.ts
+++ b/containers/socket/app/src/internal/direct-messages.client.ts
@@ -5,10 +5,14 @@ import type {
   DirectMessageHistory,
 } from '@contracts/sockets/direct-messages/direct-messages.schema';
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'https://backend:4000';
+const processEnv = globalThis as typeof globalThis & {
+  process?: { env?: Record<string, string | undefined> };
+};
+
+const BACKEND_URL = processEnv.process?.env?.BACKEND_URL ?? 'https://backend:4000';
 
 function getHeaders(): Record<string, string> {
-  const secret = process.env.SOCKET_INTERNAL_SECRET;
+  const secret = processEnv.process?.env?.SOCKET_INTERNAL_SECRET;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
@@ -60,7 +64,7 @@ export async function sendDirectMessage(args: {
   currentUserId: string;
   friendUserId: string;
   text: string;
-}): Promise<DirectMessage | null> {
+}): Promise<{ message: DirectMessage; unreadCount: number } | null> {
   try {
     const res = await fetch(`${BACKEND_URL}/internal/direct-messages/send`, {
       method: 'POST',
@@ -80,13 +84,56 @@ export async function sendDirectMessage(args: {
 
     const body = (await res.json()) as {
       ok: boolean;
-      data?: { message: DirectMessage };
+      data?: { message: DirectMessage; unreadCount: number };
     };
 
-    return body.data?.message ?? null;
+    if (!body.data?.message) return null;
+
+    return {
+      message: body.data.message,
+      unreadCount: body.data.unreadCount ?? 0,
+    };
   } catch (error) {
     logEvents.error({
       event: 'send_direct_message_error',
+      currentUserId: args.currentUserId,
+      friendUserId: args.friendUserId,
+      error,
+    });
+    return null;
+  }
+}
+
+export async function markDirectMessagesRead(args: {
+  currentUserId: string;
+  friendUserId: string;
+}): Promise<number | null> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/internal/direct-messages/read`, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify(args),
+    });
+
+    if (!res.ok) {
+      logEvents.warn({
+        event: 'mark_direct_messages_read_failed',
+        status: res.status,
+        currentUserId: args.currentUserId,
+        friendUserId: args.friendUserId,
+      });
+      return null;
+    }
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { unreadCount: number };
+    };
+
+    return body.data?.unreadCount ?? 0;
+  } catch (error) {
+    logEvents.error({
+      event: 'mark_direct_messages_read_error',
       currentUserId: args.currentUserId,
       friendUserId: args.friendUserId,
       error,


### PR DESCRIPTION
- Updated friendships repository to include friendshipId in the list of friends for a user.
- Modified friendships service to count unread direct messages for each friendship and return this count in the friends list.
- Added unreadMessageCount to the FriendPublic type in the contracts.
- Introduced new socket events for unread message updates and implemented related schemas.
- Created CountBadge component to display unread message counts in various UI components.
- Updated chat and direct messages features to handle unread message states and scrolling behavior.
- Implemented logic to mark direct messages as read and emit updates to the socket.
- Enhanced social store to manage unread message counts for friends.
- Updated friendship actions to include unread message counts in action buttons.