### PR TITLE
Game rooms connections

### DIFF
--- a/containers/frontend/web/src/app/[locale]/(public)/game/@side/default.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/game/@side/default.tsx
@@ -1,0 +1,3 @@
+export default function GameSideDefaultPage() {
+  return null;
+}

--- a/containers/frontend/web/src/app/[locale]/(public)/game/default.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/game/default.tsx
@@ -1,0 +1,3 @@
+export default function GameDefaultPage() {
+  return null;
+}

--- a/containers/frontend/web/src/features/game/game.tsx
+++ b/containers/frontend/web/src/features/game/game.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, useContext } from 'react';
 import { Canvas, type ThreeEvent } from '@react-three/fiber';
 import { Center, Environment, Html, MapControls, OrthographicCamera } from '@react-three/drei';
 import { useGame, type pos as Position } from './store';
@@ -10,6 +10,7 @@ import { Meter } from '@components/composites/meter';
 import { Stack } from '@components/primitives/stack';
 import { Text } from '@components/primitives/text';
 import { useShallow } from 'zustand/react/shallow';
+import { RoomsStoreContext } from '@/features/rooms/rooms-provider';
 import { Crawler } from './meshes/Crawler.jsx';
 import { Drone } from './meshes/Drone.jsx';
 import { Gunner } from './meshes/Gunner.jsx';
@@ -780,22 +781,30 @@ function HandlePhaseScreen() {
 }
 
 export function Game() {
+  const roomsStore = useContext(RoomsStoreContext);
   const initSocketListeners = useGame((state) => state.initSocketListeners);
   const cleanupSocketListeners = useGame((state) => state.cleanupSocketListeners);
   const assignedCharacter = useGame((state) => state.assignedCharacter);
+  const connectionError = useGame((state) => state.connectionError);
+  const activePlayers = useGame((state) => state.activePlayers);
   const mapBounds = useGame((state) => state.mapBounds);
   const [debugInfo, setDebugInfo] = useState('Initializing...');
-  const initRef = useRef(false);
-  
+  const roomState = roomsStore?.roomState;
+  const isRoomFull = roomState?.isGameRoomFull ?? false;
 
 
   useEffect(() => {
+    if (!isRoomFull) {
+      cleanupSocketListeners();
+      return;
+    }
+
     initSocketListeners();
 
     return () => {
       cleanupSocketListeners();
     };
-  }, []);
+  }, [cleanupSocketListeners, initSocketListeners, isRoomFull]);
 
   useEffect(() => {
     const debugTimer = setInterval(() => {
@@ -808,6 +817,39 @@ export function Game() {
       clearInterval(debugTimer);
     };
   }, [mapBounds]);
+
+  if (connectionError) {
+    return (
+      <div className="absolute inset-0 bg-black flex items-center justify-center text-white z-25">
+        <div className="text-center max-w-md px-6">
+          <h2>Game unavailable</h2>
+          <p className="text-sm text-gray-300 mt-4">{connectionError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isRoomFull) {
+    return (
+      <div className="absolute inset-0 bg-black flex items-center justify-center text-white z-25">
+        <div className="text-center max-w-md px-6">
+          <h2>Room not ready</h2>
+          <p className="text-sm text-gray-300 mt-4">The game route is only available when the room has 4 players.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (mapBounds.width > 0 && activePlayers.length < 4) {
+    return (
+      <div className="absolute inset-0 bg-black flex items-center justify-center text-white z-25">
+        <div className="text-center max-w-md px-6">
+          <h2>Game paused</h2>
+          <p className="text-sm text-gray-300 mt-4">A player disconnected. The game is blocked until the room is full again.</p>
+        </div>
+      </div>
+    );
+  }
 
   return !mapBounds || mapBounds.width === 0 ? (
     <div className="absolute inset-0 bg-black flex items-center justify-center text-white z-25">

--- a/containers/frontend/web/src/features/game/game.tsx
+++ b/containers/frontend/web/src/features/game/game.tsx
@@ -840,7 +840,7 @@ export function Game() {
     );
   }
 
-  if (mapBounds.width > 0 && activePlayers.length < 4) {
+  if (mapBounds.width > 0 && (activePlayers?.length ?? 0) < 4) {
     return (
       <div className="absolute inset-0 bg-black flex items-center justify-center text-white z-25">
         <div className="text-center max-w-md px-6">

--- a/containers/frontend/web/src/features/game/store.ts
+++ b/containers/frontend/web/src/features/game/store.ts
@@ -112,6 +112,7 @@ type gameState = globalGameState & localGameState & {
 
   //local state
   assignedCharacter: string;
+  connectionError: string | null;
   typeEnt: string | null;
   affected: Record<string, boolean>;
   vfx: Record<string, vfx>;
@@ -205,6 +206,7 @@ function getAoePreviewTiles(
 export const useGame = create<gameState>()((set, get) => ({
 
   assignedCharacter: 'spectator',
+  connectionError: null,
 
   turn: 1,
   doom: 0,
@@ -324,9 +326,10 @@ export const useGame = create<gameState>()((set, get) => ({
     gameSocket.off('game:server:join');
     gameSocket.off('game:server:globalSync');
     gameSocket.off('game:server:sync');
+    (gameSocket as any).off('game:server:error');
     const handleJoin = (id: string) => {
       console.log('👤 Player joined with ID:', id);
-      set({ assignedCharacter: id });
+      set({ assignedCharacter: id, connectionError: null });
     };
 
     const handleGlobalSync = (state: globalGameState) => {
@@ -415,6 +418,14 @@ export const useGame = create<gameState>()((set, get) => ({
       });
     };
 
+    const handleGameError = (message: string) => {
+      console.error('🎮 game socket error:', message);
+      set({
+        connectionError: message,
+        mapBounds: { width: 0, height: 0, depth: 0 },
+      });
+    };
+
     gameSocket.on('connect', () => {
       console.log('✅ Connected to game socket server');
     });
@@ -427,6 +438,7 @@ export const useGame = create<gameState>()((set, get) => ({
     (gameSocket as any).on('game:server:globalSync', handleGlobalSync);
     gameSocket.on('game:server:sync', handleSync);
     (gameSocket as any).on('game:server:vfx', handleVfx);
+    (gameSocket as any).on('game:server:error', handleGameError);
 
     ensureChatSessionIdentity()
       .finally(() => gameSocket.connect());
@@ -441,6 +453,7 @@ export const useGame = create<gameState>()((set, get) => ({
     (gameSocket as any).off('game:server:globalSync');
     gameSocket.off('game:server:sync');
     (gameSocket as any).off('game:server:vfx');
+    (gameSocket as any).off('game:server:error');
     gameSocket.disconnect();
   },
 }));

--- a/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
+++ b/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
@@ -4,10 +4,10 @@ import type { FormEvent } from 'react';
 import {
   Form,
   SubmitButton,
-  TextAreaField,
+  TextField,
 } from '@components';
 
-import type { gameRoomState } from '@contracts/sockets/rooms/gameRooms.schema';
+import type { gameRoomState, PlayerState } from '@/contracts/sockets/rooms/gameRooms.schema';
 
 import {
   GameRoomSocketJoinAnyRoom,
@@ -40,7 +40,7 @@ export function GameRoomTest({
   gameRoomsErrorInfo,
 }: GameRoomTestProps) {
 
-  const teammates = gameRoomStateCtx.teammates.map((user) => (
+  const teammates = gameRoomStateCtx.teammates.map((user: PlayerState) => (
     <li key={user.userId}>{user.userName} (): {user.userId}</li>
   )
   );
@@ -84,7 +84,7 @@ export function GameRoomTest({
 
       <h4>join room by id form.</h4>
       <Form onSubmit={makeGameRoomAction(GameRoomSocketJoin)}>
-        <TextAreaField
+        <TextField
           name="gameRoomId"
           labelKey="features.game.room.fields.gameRoomId"
         />

--- a/containers/frontend/web/src/i18n/messages/ca.json
+++ b/containers/frontend/web/src/i18n/messages/ca.json
@@ -318,7 +318,12 @@
     "game": {
       "endTurn": "Acabar torn",
       "healthLabel": "HP",
-      "resetPlan": "Reiniciar pla"
+      "resetPlan": "Reiniciar pla",
+      "room": {
+        "fields": {
+          "gameRoomId": "ID de la sala"
+        }
+      }
     },
     "navigation": {
       "createAccount": "Crear compte",

--- a/containers/frontend/web/src/i18n/messages/en.d.json.ts
+++ b/containers/frontend/web/src/i18n/messages/en.d.json.ts
@@ -320,7 +320,12 @@ declare const messages: {
     "game": {
       "endTurn": "End turn",
       "healthLabel": "HP",
-      "resetPlan": "Reset plan"
+      "resetPlan": "Reset plan",
+      "room": {
+        "fields": {
+          "gameRoomId": "Game room ID"
+        }
+      }
     },
     "navigation": {
       "createAccount": "Create account",

--- a/containers/frontend/web/src/i18n/messages/en.json
+++ b/containers/frontend/web/src/i18n/messages/en.json
@@ -317,7 +317,12 @@
     "game": {
       "endTurn": "End turn",
       "healthLabel": "HP",
-      "resetPlan": "Reset plan"
+      "resetPlan": "Reset plan",
+      "room": {
+        "fields": {
+          "gameRoomId": "Game room ID"
+        }
+      }
     },
     "navigation": {
       "createAccount": "Create account",

--- a/containers/frontend/web/src/i18n/messages/es.json
+++ b/containers/frontend/web/src/i18n/messages/es.json
@@ -317,7 +317,12 @@
     "game": {
       "endTurn": "Terminar turno",
       "healthLabel": "HP",
-      "resetPlan": "Reiniciar plan"
+      "resetPlan": "Reiniciar plan",
+      "room": {
+        "fields": {
+          "gameRoomId": "ID de la sala"
+        }
+      }
     },
     "navigation": {
       "createAccount": "Crear cuenta",

--- a/containers/frontend/web/src/lib/sockets/realtime-session-bridge.tsx
+++ b/containers/frontend/web/src/lib/sockets/realtime-session-bridge.tsx
@@ -40,16 +40,6 @@ function hasMountedListeners(socket: {
   return socket.listeners('connect').length > 0 || socket.listeners('disconnect').length > 0;
 }
 
-function hasMountedGameRoomListeners() {
-  return (
-    gameRoomSocket.listeners('gameRoom:room:update').length > 0
-    || gameRoomSocket.listeners('gameRoom:debug:msg').length > 0
-    || gameRoomSocket.listeners('gameRoom:error:msg').length > 0
-    || gameRoomSocket.listeners('gameRoom:room:joined').length > 0
-    || gameRoomSocket.listeners('gameRoom:room:left').length > 0
-  );
-}
-
 async function getCurrentSessionIdentity(): Promise<SessionIdentity | null> {
   const endpoint = `${envPublic.apiBaseUrl.replace(/\/$/, '')}/auth/session/identity`;
 
@@ -97,7 +87,7 @@ function getStoredRoomId() {
 
 async function rejoinStoredRoomIfNeeded() {
   const roomId = getStoredRoomId();
-  if (roomId === null || !hasMountedGameRoomListeners()) {
+  if (roomId === null) {
     return;
   }
 

--- a/containers/socket/app/src/features/game-room/GameRoomsManager.ts
+++ b/containers/socket/app/src/features/game-room/GameRoomsManager.ts
@@ -14,6 +14,11 @@ export class GameRoomsManager {
   nextGameRoomId = 1;
   gameRooms = new Map<number, gameRoomState>();
   memberRoomIds = new Map<string, number>();
+  onRoomDeleted?: (roomId: number) => void;
+
+  setOnRoomDeleted(callback: ((roomId: number) => void) | undefined) {
+    this.onRoomDeleted = callback;
+  }
 
   printInfo() {
     console.log('[ gameRoom ][ debug ] rooms: ', this.gameRooms);
@@ -141,6 +146,7 @@ export class GameRoomsManager {
 
     if (gameRoom.teammates.length === 0) {
       this.gameRooms.delete(gameRoomId);
+      this.onRoomDeleted?.(gameRoomId);
     }
 
     return gameRoom;

--- a/containers/socket/app/src/features/game-room/gameRoom.socket.ts
+++ b/containers/socket/app/src/features/game-room/gameRoom.socket.ts
@@ -62,6 +62,12 @@ function broadcastRoomUpdate(socket: Socket, gameRoomId: number, gameRoomState: 
 }
 
 function handleJoinResult(socket: Socket, username: string, gameRoom: ReturnType<typeof gameRoomsManager.joinUserToGameRoom>) {
+  if (gameRoom === 'error:no_assigned_room') {
+    emitGameRoomError(socket, 'not on any room.');
+    emitEmptyGameRoomState(socket);
+    return;
+  }
+
   if (gameRoom === 'error:alredy_joined_another_room') {
     emitGameRoomError(socket, 'alredy in a room.');
     updateGameRoomState(socket);

--- a/containers/socket/app/src/features/game-room/gameRoom.socket.ts
+++ b/containers/socket/app/src/features/game-room/gameRoom.socket.ts
@@ -62,25 +62,25 @@ function broadcastRoomUpdate(socket: Socket, gameRoomId: number, gameRoomState: 
 }
 
 function handleJoinResult(socket: Socket, username: string, gameRoom: ReturnType<typeof gameRoomsManager.joinUserToGameRoom>) {
-  if (gameRoom === 'error:no_assigned_room') {
-    emitGameRoomError(socket, 'not on any room.');
-    emitEmptyGameRoomState(socket);
-    return;
-  }
+  if (typeof gameRoom === 'string') {
+    if (gameRoom === 'error:no_assigned_room') {
+      emitGameRoomError(socket, 'not on any room.');
+      emitEmptyGameRoomState(socket);
+      return;
+    }
 
-  if (gameRoom === 'error:alredy_joined_another_room') {
-    emitGameRoomError(socket, 'alredy in a room.');
-    updateGameRoomState(socket);
-    return;
-  }
+    if (gameRoom === 'error:alredy_joined_another_room') {
+      emitGameRoomError(socket, 'alredy in a room.');
+      updateGameRoomState(socket);
+      return;
+    }
 
-  if (gameRoom === 'error:invalid_room_id') {
-    emitGameRoomError(socket, 'inexistent room');
-    updateGameRoomState(socket);
-    return;
-  }
+    if (gameRoom === 'error:invalid_room_id') {
+      emitGameRoomError(socket, 'inexistent room');
+      updateGameRoomState(socket);
+      return;
+    }
 
-  if (gameRoom === 'error:full_room') {
     emitGameRoomError(socket, 'room is full.');
     updateGameRoomState(socket);
     return;

--- a/containers/socket/app/src/features/game/GameSessionManager.ts
+++ b/containers/socket/app/src/features/game/GameSessionManager.ts
@@ -1,0 +1,63 @@
+import type { gameRoomState } from '@contracts/sockets/rooms/gameRooms.schema';
+
+import { initState } from './utils';
+import type { GameSession } from './game-session.types';
+import type { serverGameState } from './types';
+
+const DEFAULT_ROLES = ['assassin', 'paladin', 'mage', 'alchemist'] as const;
+
+function createInitialServerState(): serverGameState {
+  const init = initState();
+  return {
+    phase: 'PLAN',
+    turn: 1,
+    doom: 0,
+    players: init.players,
+    ghosts: {},
+    clones: {},
+    enemies: init.enemies,
+    tiles: init.tiles,
+    clients: {},
+    history: [],
+    mapBounds: init.mapBounds,
+    forcedMoveOrigins: {},
+    planningStatusOrigins: {},
+  };
+}
+
+export class GameSessionManager {
+  private sessions = new Map<number, GameSession>();
+
+  getOrCreateSession(gameRoom: gameRoomState): GameSession {
+    const existing = this.sessions.get(gameRoom.id);
+    if (existing) {
+      return existing;
+    }
+
+    const session: GameSession = {
+      roomId: gameRoom.id,
+      channel: `GameRoom-${gameRoom.id}`,
+      state: createInitialServerState(),
+      players: new Map(),
+      readyPlayers: new Set(),
+      availableRoles: [...DEFAULT_ROLES].reverse(),
+    };
+
+    this.sessions.set(gameRoom.id, session);
+    return session;
+  }
+
+  getSession(roomId: number) {
+    return this.sessions.get(roomId);
+  }
+
+  deleteSession(roomId: number) {
+    this.sessions.delete(roomId);
+  }
+
+  hasSession(roomId: number) {
+    return this.sessions.has(roomId);
+  }
+}
+
+export const gameSessionManager = new GameSessionManager();

--- a/containers/socket/app/src/features/game/game-session.types.ts
+++ b/containers/socket/app/src/features/game/game-session.types.ts
@@ -1,0 +1,21 @@
+import type { clientGameState, serverGameState } from './types';
+
+export type PlayerRole = 'assassin' | 'paladin' | 'mage' | 'alchemist';
+
+export type GameSessionStatus = 'connected' | 'disconnected' | 'spectator';
+
+export type GameSessionPlayer = {
+  memberKey: string;
+  role: PlayerRole | 'spectator';
+  socketId: string;
+  status: GameSessionStatus;
+};
+
+export type GameSession = {
+  roomId: number;
+  channel: string;
+  state: serverGameState;
+  players: Map<string, GameSessionPlayer>;
+  readyPlayers: Set<PlayerRole>;
+  availableRoles: PlayerRole[];
+};

--- a/containers/socket/app/src/features/game/game.socket.ts
+++ b/containers/socket/app/src/features/game/game.socket.ts
@@ -3,13 +3,33 @@ import type {
   ClientToServerGameEvents,
   ServerToClientGameEvents as ContractServerToClientGameEvents,
 } from '@contracts/sockets/game/game.schema';
-import { initState, gameState, dijkstra, getAbility, initClientGameState, setClear, paint, addHistory, resetHistory, moveClone, nextPhase, applyPlanningDisplace, applyPlanningStatus, checkEnt, getAoE, nextVfxId } from './utils';
-import type { clientGameState, serverGameState, vfx as VfxPayload } from './types';
 
-const roles: string[] = ['assassin', 'paladin', 'mage', 'alchemist'];
-const playerIds: string[] = [...roles].reverse();
-const users: Record<string, string> = {};
-const readyPlayers: string[] = [];
+import { gameSessionManager } from './GameSessionManager';
+import type { GameSession, PlayerRole } from './game-session.types';
+import {
+  addHistory,
+  applyPlanningDisplace,
+  applyPlanningStatus,
+  checkEnt,
+  dijkstra,
+  getAbility,
+  getAoE,
+  initClientGameState,
+  moveClone,
+  nextPhase,
+  nextVfxId,
+  paint,
+  resetHistory,
+  runWithGameState,
+  setClear,
+} from './utils';
+import {
+  gameRoomsManager,
+  getRoomMemberKey,
+  getUserGameRoom,
+} from '../game-room/gameRooms.shared';
+import type { gameRoomState } from '@contracts/sockets/rooms/gameRooms.schema';
+import type { clientGameState, serverGameState, vfx as VfxPayload } from './types';
 
 type ServerGlobalSyncPayload = Omit<serverGameState, 'clients' | 'tiles' | 'mapBounds'> & {
   tiles?: serverGameState['tiles'];
@@ -25,220 +45,351 @@ type ServerToClientGameEvents = Omit<
   'game:server:globalSync': (state: ServerGlobalSyncPayload) => void;
   'game:server:sync': (state: clientGameState) => void;
   'game:server:vfx': (effect: VfxPayload) => void;
+  'game:server:error': (message: string) => void;
 };
 
+function getSessionPlayerRoleCount(session: GameSession) {
+  return [...session.players.values()].filter((player) => player.role !== 'spectator').length;
+}
+
+function getActivePlayerRoles(session: GameSession) {
+  return [...session.players.values()]
+    .filter((player) => player.role !== 'spectator' && player.status === 'connected')
+    .map((player) => player.role as PlayerRole);
+}
+
+function getClientKey(role: PlayerRole | 'spectator', memberKey: string) {
+  return role === 'spectator' ? `spectator:${memberKey}` : role;
+}
+
+function getPlayerClientState(session: GameSession, role: PlayerRole | 'spectator', memberKey: string) {
+  return session.state.clients[getClientKey(role, memberKey)];
+}
+
+function gsync(
+  nsp: Namespace<ClientToServerGameEvents, ServerToClientGameEvents>,
+  session: GameSession,
+) {
+  const { tiles, mapBounds, clients, ...send } = session.state;
+  nsp.to(session.channel).emit('game:server:globalSync', {
+    ...send,
+    readyPlayers: [...session.readyPlayers],
+    activePlayers: getActivePlayerRoles(session),
+  });
+}
+
+function syncFullGlobalState(
+  socket: Socket<ClientToServerGameEvents, ServerToClientGameEvents>,
+  session: GameSession,
+) {
+  socket.emit('game:server:globalSync', {
+    ...session.state,
+    readyPlayers: [...session.readyPlayers],
+    activePlayers: getActivePlayerRoles(session),
+  });
+}
+
+function vfx(
+  nsp: Namespace<ClientToServerGameEvents, ServerToClientGameEvents>,
+  session: GameSession,
+  effect: VfxPayload,
+) {
+  nsp.to(session.channel).emit('game:server:vfx', effect);
+}
+
+function syncClient(
+  socket: Socket<ClientToServerGameEvents, ServerToClientGameEvents>,
+  session: GameSession,
+  role: PlayerRole | 'spectator',
+  memberKey: string,
+) {
+  const clientState = getPlayerClientState(session, role, memberKey);
+  if (clientState) {
+    socket.emit('game:server:sync', clientState);
+  }
+}
+
+function syncAllClients(
+  nsp: Namespace<ClientToServerGameEvents, ServerToClientGameEvents>,
+  session: GameSession,
+) {
+  for (const player of session.players.values()) {
+    if (player.status !== 'connected') {
+      continue;
+    }
+    const clientState = getPlayerClientState(session, player.role, player.memberKey);
+    if (clientState) {
+      nsp.to(player.socketId).emit('game:server:sync', clientState);
+    }
+  }
+}
+
+function attachPlayerToSession(
+  session: GameSession,
+  memberKey: string,
+  socketId: string,
+) {
+  const existing = session.players.get(memberKey);
+  if (existing) {
+    existing.socketId = socketId;
+    existing.status = existing.role === 'spectator' ? 'spectator' : 'connected';
+    const clientKey = getClientKey(existing.role, memberKey);
+    session.state.clients[clientKey] ??= initClientGameState(socketId);
+    return existing;
+  }
+
+  const role = session.availableRoles.pop() ?? 'spectator';
+  const player = {
+    memberKey,
+    role,
+    socketId,
+    status: role === 'spectator' ? 'spectator' : 'connected',
+  } as const;
+
+  session.players.set(memberKey, { ...player });
+  const clientKey = getClientKey(role, memberKey);
+  session.state.clients[clientKey] = initClientGameState(socketId);
+  return session.players.get(memberKey)!;
+}
+
+function releasePlayerRole(session: GameSession, memberKey: string) {
+  const player = session.players.get(memberKey);
+  if (!player) {
+    return;
+  }
+
+  session.players.delete(memberKey);
+
+  if (player.role !== 'spectator') {
+    session.readyPlayers.delete(player.role);
+    if (!session.availableRoles.includes(player.role)) {
+      session.availableRoles.push(player.role);
+    }
+  }
+
+  delete session.state.clients[getClientKey(player.role, memberKey)];
+}
+
+function reconcileSessionWithRoom(session: GameSession, gameRoom: gameRoomState) {
+  const currentMemberKeys = new Set(gameRoom.teammates.map((teammate) => teammate.userId));
+
+  for (const memberKey of [...session.players.keys()]) {
+    if (!currentMemberKeys.has(memberKey)) {
+      releasePlayerRole(session, memberKey);
+    }
+  }
+}
+
+async function withSessionState<T>(session: GameSession, operation: () => Promise<T> | T) {
+  return runWithGameState(session.state, operation);
+}
+
+gameRoomsManager.setOnRoomDeleted((roomId) => {
+  gameSessionManager.deleteSession(roomId);
+});
 
 export function registerGameSocket(nsp: Namespace<ClientToServerGameEvents, ServerToClientGameEvents>) {
+  nsp.on('connection', async (socket: Socket<ClientToServerGameEvents, ServerToClientGameEvents>) => {
+    const memberKey = getRoomMemberKey(socket);
+    const gameRoom = getUserGameRoom(socket);
 
-  function gsync() {
-    const { tiles, mapBounds, clients, ...send } = gameState;
-    const activePlayers = roles.filter((r) => !playerIds.includes(r));
-    nsp.emit('game:server:globalSync', {
-      ...send,
-      readyPlayers,
-      activePlayers,
-    });
-  }
-
-  function vfx(effect: VfxPayload) {
-    nsp.emit('game:server:vfx', effect);
-  }
-
-  nsp.on('connection', (socket: Socket<ClientToServerGameEvents, ServerToClientGameEvents>) => {
-    if (playerIds.length === 4) {
-      console.log('init state happens !!!!!!');
-      const initstate = initState();
-      gameState.turn = 1;
-      gameState.doom = 0;
-      gameState.players = initstate.players;
-      gameState.enemies = initstate.enemies;
-      gameState.tiles = initstate.tiles;
-      gameState.mapBounds = initstate.mapBounds;
-      gameState.clones = {};
-      gameState.ghosts = {};
-      gameState.history = [];
-      gameState.forcedMoveOrigins = {};
-      gameState.planningStatusOrigins = {};
+    if (!memberKey || !gameRoom) {
+      (socket as any).emit('game:server:error', 'No active game room for this socket.');
+      socket.disconnect(true);
+      return;
     }
-    // WARN: DO NOT CHANGE, else will not render the map 
-    nsp.emit('game:server:globalSync', gameState);
-    const role = playerIds.pop();
-    if (!role) {
-      console.log('Room full, spectator joined:', socket.id);
-      gameState.clients['spectator'] = initClientGameState(socket.id);
-      gsync();
-      socket.emit('game:server:join', 'spectator');
-    }
-    else {
-      users[socket.id] = role;
-      gameState.clients[role] = initClientGameState(socket.id);
-      socket.emit('game:server:join', role);
-      gsync();
-      if (gameState.clients[role])
-        socket.emit('game:server:sync', gameState.clients[role]);
 
-      socket.on('game:client:showMoveRange', (diceValue: number) => {
-        if (!gameState.clients[role] || !role || !gameState.clients[role].selectedEnt)
+    if (!gameRoom.isGameRoomFull) {
+      (socket as any).emit('game:server:error', 'Game is only available when the room is full.');
+      socket.disconnect(true);
+      return;
+    }
+
+    const session = gameSessionManager.getOrCreateSession(gameRoom);
+    reconcileSessionWithRoom(session, gameRoom);
+    const sessionPlayer = attachPlayerToSession(session, memberKey, socket.id);
+    const role = sessionPlayer.role;
+
+    await socket.join(session.channel);
+    socket.emit('game:server:join', role);
+    syncFullGlobalState(socket, session);
+    gsync(nsp, session);
+    syncClient(socket, session, role, memberKey);
+
+    socket.on('game:client:showMoveRange', async (diceValue: number) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client || role === 'spectator' || !client.selectedEnt)
           return;
-        const selectedEnt = gameState.clients[role].selectedEnt;
-        const playerClone = gameState.clones?.[`clone_${role}`];
-        if (selectedEnt?.startsWith('clone_') && playerClone?.hasMoved === true)
-          return (console.log(role, 'has already moved'));
-        console.log('Received move range event with dice:',
-          diceValue, 'for character', role);
-        const selEnt = gameState.clients[role].selectedEnt;
-        if (!selEnt)
+        const selectedEnt = client.selectedEnt;
+        const playerClone = session.state.clones?.[`clone_${role}`];
+        if (selectedEnt.startsWith('clone_') && playerClone?.hasMoved === true)
           return;
-        const ent = gameState.players[selEnt] || gameState.ghosts[selEnt]
-          || gameState.enemies[selEnt] || gameState.clones[selEnt];
+        const ent = session.state.players[selectedEnt] || session.state.ghosts[selectedEnt]
+          || session.state.enemies[selectedEnt] || session.state.clones[selectedEnt];
         if (!ent)
           return;
-        const hlId = dijkstra(selEnt, ent.position, diceValue)
+        const hlId = dijkstra(selectedEnt, ent.position, diceValue);
         const hlTiles: Record<string, boolean> = {};
         hlId.forEach((id: string) => (hlTiles[id] = true));
-        setClear(role);
-        gameState.clients[role].highlights = hlTiles;
-        socket.emit('game:server:sync', gameState.clients[role]);
+        setClear(getClientKey(role, memberKey));
+        client.highlights = hlTiles;
       });
+      syncClient(socket, session, role, memberKey);
+    });
 
-      socket.on('game:client:displayMoveRange', (diceValue: number) => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:displayMoveRange', async (diceValue: number) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client || role === 'spectator')
           return;
-        if (gameState.clones[`clone_${role}`]?.hasMoved === true)
-          return (console.log(role, 'has already moved'));
-        console.log('Received move range event with dice:',
-          diceValue, 'for character', role);
-        const selEnt = gameState.clients[role].selectedEnt;
-        if (selEnt?.replace("clone_", "") !== role)
+        if (session.state.clones[`clone_${role}`]?.hasMoved === true)
           return;
-        const ent = gameState.players[role] || gameState.clones[selEnt];
+        const selEnt = client.selectedEnt;
+        if (selEnt?.replace('clone_', '') !== role)
+          return;
+        const ent = session.state.players[role] || session.state.clones[selEnt];
         if (!ent)
           return;
         const hlId = dijkstra(selEnt, ent.position, diceValue);
         const hlTiles: Record<string, boolean> = {};
         hlId.forEach((id: string) => (hlTiles[id] = true));
-        gameState.clients[role].highlights = hlTiles;
-        gameState.clients[role].selectedDice = diceValue;
-        socket.emit('game:server:sync', gameState.clients[role])
+        client.highlights = hlTiles;
+        client.selectedDice = diceValue;
       });
+      syncClient(socket, session, role, memberKey);
+    });
 
-      socket.on('game:client:selectEntity', (id: string) => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:selectEntity', async (id: string) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
           return;
-        setClear(role);
-        gameState.clients[role].selectedEnt =
-          (id === gameState.clients[role].selectedEnt) ? null : id;
-        socket.emit('game:server:sync', gameState.clients[role])
-      })
-
-      socket.on('game:client:selectDice', (diceValue: number) => {
-        gameState.clients[role].selectedDice =
-          (gameState.clients[role].selectedDice === diceValue
-            || !gameState.clients[role].selectedEnt) ? null : diceValue;
-        socket.emit('game:server:sync', gameState.clients[role])
+        setClear(getClientKey(role, memberKey));
+        client.selectedEnt = id === client.selectedEnt ? null : id;
       });
+      syncClient(socket, session, role, memberKey);
+    });
 
-      socket.on('game:client:displayAbilityRange', (who: string, abName: string) => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:selectDice', async (diceValue: number) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
           return;
-        const ent = gameState.players[who] || gameState.clones[who] || gameState.enemies[who];
-        if (!ent) return;
-        console.log('Received ability range event for character', role);
-        if (gameState.clients[role].selectedAb === abName)
-          setClear(role);
-        else {
+        client.selectedDice = (client.selectedDice === diceValue || !client.selectedEnt) ? null : diceValue;
+      });
+      syncClient(socket, session, role, memberKey);
+    });
+
+    socket.on('game:client:displayAbilityRange', async (who: string, abName: string) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
+          return;
+        const ent = session.state.players[who] || session.state.clones[who] || session.state.enemies[who];
+        if (!ent)
+          return;
+        if (client.selectedAb === abName) {
+          setClear(getClientKey(role, memberKey));
+        } else {
           const ab = getAbility(abName);
-          setClear(role);
-          gameState.clients[role].selectedAb = abName;
-          gameState.clients[role].selectables = paint(role, ent.position, ab.type, ab.range, ab.self);
-          gameState.clients[role].canSelect = false;
-          // WARN: not enough time :( 
-          // INFO: liar above, just lazy
-
-          // if (ab.AoE)
-          //   gameState.clients[role].selectables = paint(role, ent.position, ab.type, ab.range, ab.self);
+          setClear(getClientKey(role, memberKey));
+          client.selectedAb = abName;
+          client.selectables = paint(role, ent.position, ab.type, ab.range, ab.self);
+          client.canSelect = false;
         }
-        socket.emit('game:server:sync', gameState.clients[role])
       });
+      syncClient(socket, session, role, memberKey);
+    });
 
-      socket.on('game:client:showAbilityRange', (who: string, abName: string) => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:showAbilityRange', async (who: string, abName: string) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
           return;
-        console.log('Received show ability range event for character', role);
-        const ent = gameState.players[who] || gameState.clones[who] || gameState.enemies[who];
-        if (!ent) return;
-        if (gameState.clients[role].selectedAb === abName)
-          setClear(role);
-        else {
+        const ent = session.state.players[who] || session.state.clones[who] || session.state.enemies[who];
+        if (!ent)
+          return;
+        if (client.selectedAb === abName) {
+          setClear(getClientKey(role, memberKey));
+        } else {
           const { type, range, self } = getAbility(abName);
-          gameState.clients[role].selectables = paint(role, ent.position, type, range, self);
+          client.selectables = paint(role, ent.position, type, range, self);
         }
-        socket.emit('game:server:sync', gameState.clients[role])
       });
+      syncClient(socket, session, role, memberKey);
+    });
 
-      socket.on('game:client:clearHl', () => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:clearHl', async () => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
           return;
-        console.log('Received highlight clear event for character', users[socket.id]);
-        gameState.clients[role].highlights = {};
-        gameState.clients[role].selectedDice = null;
+        client.highlights = {};
+        client.selectedDice = null;
       });
+    });
 
-      socket.on('game:client:clearSl', () => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:clearSl', async () => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
           return;
-        console.log('Received selectables clear event for character', users[socket.id]);
-        gameState.clients[role].selectables = {};
-        gameState.clients[role].selectedDice = null;
-        gameState.clients[role].canSelect = true;
+        client.selectables = {};
+        client.selectedDice = null;
+        client.canSelect = true;
       });
+    });
 
-      socket.on('game:client:clearSelDice', () => {
-        if (!gameState.clients[role] || !role)
+    socket.on('game:client:clearSelDice', async () => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
           return;
-        console.log('Received selected dice clear event for character', users[socket.id]);
-        gameState.clients[role].selectedDice = null;
+        client.selectedDice = null;
       });
+    });
 
-      socket.on('game:client:moveClone', (tileId: string) => {
-        console.log('Received move clone event for character', users[socket.id]);
-        const client = gameState.clients[role];
-        if (!client || !role || !tileId)
+    socket.on('game:client:moveClone', async (tileId: string) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client || role === 'spectator' || !tileId)
           return;
         if (!client.highlights[tileId] || !client.selectedEnt || !client.selectedDice)
           return;
         moveClone(role, tileId, client.selectedDice);
-        gameState.clients[role].selectedEnt = `clone_${role}`;
-        setClear(role);
-        socket.emit('game:server:sync', gameState.clients[role]);
-        gsync();
+        client.selectedEnt = `clone_${role}`;
+        setClear(getClientKey(role, memberKey));
       });
+      syncClient(socket, session, role, memberKey);
+      gsync(nsp, session);
+    });
 
-      socket.on('game:client:addHistoryAbility', (target: string) => {
-        console.log('selected ent:', gameState.clients[role].selectedEnt);
-        console.log('selected dice:', gameState.clients[role].selectedDice);
-        console.log('selected ab:', gameState.clients[role].selectedAb);
-        const entid = gameState.clients[role].selectedEnt;
-        const seldice = gameState.clients[role].selectedDice;
-        const abName = gameState.clients[role].selectedAb;
+    socket.on('game:client:addHistoryAbility', async (target: string) => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client)
+          return;
+        const entid = client.selectedEnt;
+        const seldice = client.selectedDice;
+        const abName = client.selectedAb;
         if (!entid || !seldice || !abName)
-          return (console.log("couldn't add ability to history!"));
-        const abilityActionId = addHistory(entid, "ability", target, seldice, abName);
-        const source = gameState.players[entid] || gameState.clones[entid];
+          return;
+        const abilityActionId = addHistory(entid, 'ability', target, seldice, abName);
+        const source = session.state.players[entid] || session.state.clones[entid];
         if (!source)
-          return (console.log("couldn't find a valid source in addAbilityHistory!"));
-        if (source.type === "player") {
-          setClear(role);
-          gameState.players[entid] = {
-            ...gameState.players[entid],
+          return;
+        if (source.type === 'player') {
+          setClear(getClientKey(role, memberKey));
+          session.state.players[entid] = {
+            ...session.state.players[entid],
             dice: source.dice.toSpliced(source.dice.indexOf(seldice), 1),
             usedDice: [...source.usedDice, seldice].sort((a, b) => a - b),
-          }
-        }
-        else if (source.type === "clone") {
-          setClear(role);
-          gameState.clones[entid].dice = source.dice.toSpliced(source.dice.indexOf(seldice), 1);
-          gameState.clones[entid].usedDice = [...source.usedDice, seldice].sort((a, b) => a - b);
+          };
+        } else if (source.type === 'clone') {
+          setClear(getClientKey(role, memberKey));
+          session.state.clones[entid].dice = source.dice.toSpliced(source.dice.indexOf(seldice), 1);
+          session.state.clones[entid].usedDice = [...source.usedDice, seldice].sort((a, b) => a - b);
         }
         if (abilityActionId) {
           const ab = getAbility(abName);
@@ -256,15 +407,15 @@ export function registerGameSocket(nsp: Namespace<ClientToServerGameEvents, Serv
                 } else {
                   const baseId = target.replace('clone_', '');
                   const centEnt =
-                    gameState.players[baseId] ??
-                    gameState.enemies[baseId] ??
-                    gameState.clones[`clone_${baseId}`] ??
-                    gameState.clones[target];
+                    session.state.players[baseId] ??
+                    session.state.enemies[baseId] ??
+                    session.state.clones[`clone_${baseId}`] ??
+                    session.state.clones[target];
                   if (centEnt) centerPos = { ...(centEnt as any).position };
                 }
                 if (ab.collisionRejects && aoeTargets.length >= 2) {
                   for (const aoeId of aoeTargets) {
-                    vfx({
+                    vfx(nsp, session, {
                       vfxid: nextVfxId(`plan_col_${aoeId}`),
                       eid: aoeId,
                       type: 'damage',
@@ -286,20 +437,18 @@ export function registerGameSocket(nsp: Namespace<ClientToServerGameEvents, Serv
                 }
               }
             }
-          }
-          else if (ab.effect && ab.effect[0]) {
+          } else if (ab.effect && ab.effect[0]) {
             applyPlanningStatus(entid, target, ab, abilityActionId);
             let vfxEid: string | null = null;
             if (!target.includes(',')) {
               vfxEid = target;
-            }
-            else {
+            } else {
               const [x, y, z] = target.split(',').map(Number);
               const entOnTile = checkEnt(x, y + 1, z);
               if (entOnTile && !entOnTile.isDead) vfxEid = entOnTile.id;
             }
             if (vfxEid) {
-              vfx({
+              vfx(nsp, session, {
                 vfxid: nextVfxId(`plan_${ab.effect[0]}_${vfxEid}`),
                 eid: vfxEid,
                 type: ab.effect[0],
@@ -308,72 +457,85 @@ export function registerGameSocket(nsp: Namespace<ClientToServerGameEvents, Serv
             }
           }
         }
-        setClear(role);
-        socket.emit('game:server:sync', gameState.clients[role]);
-        gsync();
+        setClear(getClientKey(role, memberKey));
       });
-
-      socket.on('game:client:toggleEndTurn', () => {
-        if (!gameState.clients[role] || !role)
-          return;
-        if (readyPlayers.includes(role)) {
-          setClear(role);
-          readyPlayers.splice(readyPlayers.indexOf(role), 1);
-          console.log('readyPlayers', readyPlayers);
-        }
-        else {
-          readyPlayers.push(role);
-          setClear(role);
-          gameState.clients[role].selectedEnt = null;
-          gameState.clients[role].canSelect = false;
-          console.log('readyPlayers', readyPlayers);
-        }
-        socket.emit('game:server:sync', gameState.clients[role]);
-        gsync();
-      });
-
-      socket.on('game:client:nextPhase',
-        async () => {
-          if (!gameState.clients[role] || !role)
-            return;
-          console.log('readyPlayers before nextphase', readyPlayers);
-          if (readyPlayers.length === 4 - playerIds.length) {
-            console.log('readyPlayers in nextphase', readyPlayers);
-            readyPlayers.length = 0;
-            await nextPhase(gsync, vfx);
-            for (const id in gameState.clients) {
-              setClear(id);
-              nsp.emit('game:server:sync', gameState.clients[id]);
-            }
-          }
-        },
-      );
-
-      socket.on('game:client:resetHistory', () => {
-        resetHistory(role);
-        setClear(role);
-        gameState.clients[role].selectedEnt = null;
-        socket.emit('game:server:sync', gameState.clients[role]);
-        gsync();
-      });
-
-      socket.on('game:client:sync', () => {
-        socket.emit('game:server:sync', gameState.clients[role]);
-      });
-
-      socket.on('game:client:globalSync', () => {
-        gsync();
-      });
-    }
-    socket.on('disconnect', () => {
-      if (role) {
-        playerIds.push(role);
-        delete users[socket.id];
-        const ri = readyPlayers.indexOf(role);
-        if (ri !== -1) readyPlayers.splice(ri, 1);
-        console.log(role, 'disconnected, role', playerIds[playerIds.length - 1], 'is available again.');
-        gsync();
-      }
+      syncClient(socket, session, role, memberKey);
+      gsync(nsp, session);
     });
-  })
+
+    socket.on('game:client:toggleEndTurn', async () => {
+      await withSessionState(session, () => {
+        const client = getPlayerClientState(session, role, memberKey);
+        if (!client || role === 'spectator')
+          return;
+        if (session.readyPlayers.has(role)) {
+          setClear(getClientKey(role, memberKey));
+          session.readyPlayers.delete(role);
+        } else {
+          session.readyPlayers.add(role);
+          setClear(getClientKey(role, memberKey));
+          client.selectedEnt = null;
+          client.canSelect = false;
+        }
+      });
+      syncClient(socket, session, role, memberKey);
+      gsync(nsp, session);
+    });
+
+    socket.on('game:client:nextPhase', async () => {
+      if (role === 'spectator')
+        return;
+      const assignedPlayers = getSessionPlayerRoleCount(session);
+      if (session.readyPlayers.size !== assignedPlayers)
+        return;
+
+      session.readyPlayers.clear();
+      await withSessionState(session, async () => {
+        await nextPhase(
+          () => gsync(nsp, session),
+          (effect) => vfx(nsp, session, effect),
+        );
+        for (const key in session.state.clients) {
+          setClear(key);
+        }
+      });
+      syncAllClients(nsp, session);
+      gsync(nsp, session);
+    });
+
+    socket.on('game:client:resetHistory', async () => {
+      if (role === 'spectator')
+        return;
+      await withSessionState(session, () => {
+        resetHistory(role);
+        setClear(getClientKey(role, memberKey));
+        const client = getPlayerClientState(session, role, memberKey);
+        if (client) {
+          client.selectedEnt = null;
+        }
+      });
+      syncClient(socket, session, role, memberKey);
+      gsync(nsp, session);
+    });
+
+    socket.on('game:client:sync', () => {
+      syncClient(socket, session, role, memberKey);
+    });
+
+    socket.on('game:client:globalSync', () => {
+      syncFullGlobalState(socket, session);
+    });
+
+    socket.on('disconnect', () => {
+      const player = session.players.get(memberKey);
+      if (!player) {
+        return;
+      }
+      player.status = player.role === 'spectator' ? 'spectator' : 'disconnected';
+      if (player.role !== 'spectator') {
+        session.readyPlayers.delete(player.role);
+      }
+      gsync(nsp, session);
+    });
+  });
 }

--- a/containers/socket/app/src/features/game/utils.ts
+++ b/containers/socket/app/src/features/game/utils.ts
@@ -25,6 +25,30 @@ export const gameState: serverGameState = {
   planningStatusOrigins: {}
 };
 
+let stateQueue = Promise.resolve();
+
+function applyState(target: serverGameState, source: serverGameState) {
+  for (const key of Object.keys(target) as Array<keyof serverGameState>) {
+    delete (target as Record<string, unknown>)[key];
+  }
+  Object.assign(target, source);
+}
+
+export async function runWithGameState<T>(state: serverGameState, operation: () => Promise<T> | T): Promise<T> {
+  const run = async () => {
+    applyState(gameState, state);
+    try {
+      return await operation();
+    } finally {
+      applyState(state, gameState);
+    }
+  };
+
+  const result = stateQueue.then(run);
+  stateQueue = result.then(() => undefined, () => undefined);
+  return result;
+}
+
 export function initClientGameState(id: string) {
   return ({
     id: id,


### PR DESCRIPTION
# Connect game access to room state

## Summary

This PR connects the game screen with the room state so the game only starts when the room is ready.

## Changes

* Added default route files for the game parallel route.
* Connected `Game` to `RoomsStoreContext`.
* Blocked game initialization until the room has 4 players.
* Added UI states for:

  * room not ready
  * game unavailable
  * game paused after player disconnect
* Added `connectionError` state to the game store.
* Added listener handling for `game:server:error`.
* Cleaned up game socket listeners on unmount or when the room is no longer full.
* Fixed typing in the game room test component.

## Why

The game should not initialize independently from the room lifecycle.
This prevents users from entering or continuing the game when the room is incomplete, disconnected, or rejected by the game socket server.

## Testing

* Join a game room with fewer than 4 players.
* Verify the game does not start.
* Join with 4 players.
* Verify the game initializes.
* Disconnect one player.
* Verify the game pauses or blocks until the room is full again.
* Verify game socket errors are shown in the UI.
