### PR TITLE
326 fix mobile dashboard layout clipping game room actions

### DIFF
--- a/containers/docker-compose.prod.yml
+++ b/containers/docker-compose.prod.yml
@@ -41,5 +41,5 @@ services:
 
   nginx:
     ports:
-      - "443:443"
+      - "8443:443"
     restart: unless-stopped

--- a/containers/frontend/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/containers/frontend/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -19,6 +19,9 @@ export default async function SocialLayout({ children }: SocialLayoutProps) {
 
   return (
     <SplitScreenGrid
+      mobileStackMode="split"
+      mobileFullClassName="min-h-[60dvh]"
+      mobileSideClassName="min-h-[40dvh]"
       full={
         <section className="flex h-full flex-col md:p-20" aria-labelledby="game-rooms-heading">
           <h2 id="game-rooms-heading" className="sr-only">
@@ -27,7 +30,6 @@ export default async function SocialLayout({ children }: SocialLayoutProps) {
           <GameRoomsPanel />
         </section>
       }
-      mobileStackMode="split"
       side={
         <aside
           className={cn(

--- a/containers/frontend/web/src/app/[locale]/(public)/game/@side/page.styles.ts
+++ b/containers/frontend/web/src/app/[locale]/(public)/game/@side/page.styles.ts
@@ -1,4 +1,4 @@
 export const gameSidePageStyles = {
-  toggleButton: 'absolute right-4 top-16 z-20 pointer-events-auto md:top-4',
-  chatWrapper: 'h-full w-full md:ml-auto',
+  toggleButton: 'absolute right-4 top-16 z-20 pointer-events-auto lg:hidden lg:top-4',
+  chatWrapper: 'h-full w-full lg:ml-auto',
 };

--- a/containers/frontend/web/src/app/[locale]/(public)/game/@side/page.tsx
+++ b/containers/frontend/web/src/app/[locale]/(public)/game/@side/page.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { IconButton } from '@components';
 import { ChatFeature } from '@/features/chat';
+import { useMediaQuery } from '@/hooks/use-media-query';
 import {
   MOBILE_MENU_CLOSE_EVENT,
   MOBILE_MENU_OPEN_EVENT,
@@ -14,6 +15,8 @@ export default function GameSidePage() {
   const t = useTranslations('features.chat');
   const [chatVisible, setChatVisible] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
+  const isChatVisible = isDesktop ? true : chatVisible;
 
   useEffect(() => {
     const closeChat = () => {
@@ -45,14 +48,14 @@ export default function GameSidePage() {
         <IconButton
           onPress={() => setChatVisible((v) => !v)}
           icon="messages"
-          label={chatVisible ? t('hideChat') : t('showChat')}
+          label={isChatVisible ? t('hideChat') : t('showChat')}
           className={gameSidePageStyles.toggleButton}
           placement="left"
         />
       )}
 
       <div className={gameSidePageStyles.chatWrapper}>
-        <ChatFeature isVisible={chatVisible} />
+        <ChatFeature isVisible={isChatVisible} />
       </div>
     </>
   );

--- a/containers/frontend/web/src/components/primitives/split-screen-grid/split-screen-grid.styles.ts
+++ b/containers/frontend/web/src/components/primitives/split-screen-grid/split-screen-grid.styles.ts
@@ -6,15 +6,19 @@ export type SplitScreenGridMobileSideLayout = 'stack' | 'overlay';
 type SplitScreenGridStylesArgs = {
   mobileStackMode: SplitScreenGridMobileStackMode;
   mobileSideLayout: SplitScreenGridMobileSideLayout;
+  mobileFullClassName?: string;
+  mobileSideClassName?: string;
 };
 
 export function splitScreenGridStyles({
   mobileStackMode,
   mobileSideLayout,
+  mobileFullClassName,
+  mobileSideClassName,
 }: SplitScreenGridStylesArgs) {
   const isMobileSplit = mobileStackMode === 'split';
-  const mobileFullHeight = isMobileSplit ? 'h-[30dvh]' : 'h-[100dvh]';
-  const mobileSideHeight = isMobileSplit ? 'h-[70dvh]' : 'h-[100dvh]';
+  const mobileFullHeight = mobileFullClassName ?? (isMobileSplit ? 'h-[30dvh]' : 'h-[100dvh]');
+  const mobileSideHeight = mobileSideClassName ?? (isMobileSplit ? 'h-[70dvh]' : 'h-[100dvh]');
   const mobileSidePosition =
     mobileSideLayout === 'overlay' ? 'absolute inset-0 h-[100dvh]' : mobileSideHeight;
 
@@ -22,7 +26,7 @@ export function splitScreenGridStyles({
     wrapper:
       'relative flex w-full flex-col md:absolute md:inset-0 md:grid md:max-h-screen md:max-h-[100dvh] md:flex-1 md:grid-cols-[8fr_4fr]',
     full: cn(
-      `relative order-1 min-w-0 overflow-hidden ${mobileFullHeight} md:order-none md:col-span-2 md:col-start-1 md:row-start-1 md:h-screen md:h-[100dvh]`,
+      `relative order-1 min-w-0 overflow-y-auto overflow-x-hidden md:overflow-hidden ${mobileFullHeight} md:order-none md:col-span-2 md:col-start-1 md:row-start-1 md:h-screen md:h-[100dvh]`,
     ),
     side: cn(
       `z-30 order-2 min-w-0 ${mobileSidePosition} pointer-events-none md:order-none md:relative md:col-start-2 md:row-start-1 md:h-screen md:h-[100dvh] md:inset-auto`,

--- a/containers/frontend/web/src/components/primitives/split-screen-grid/split-screen-grid.styles.ts
+++ b/containers/frontend/web/src/components/primitives/split-screen-grid/split-screen-grid.styles.ts
@@ -17,19 +17,19 @@ export function splitScreenGridStyles({
   mobileSideClassName,
 }: SplitScreenGridStylesArgs) {
   const isMobileSplit = mobileStackMode === 'split';
-  const mobileFullHeight = mobileFullClassName ?? (isMobileSplit ? 'h-[30dvh]' : 'h-[100dvh]');
-  const mobileSideHeight = mobileSideClassName ?? (isMobileSplit ? 'h-[70dvh]' : 'h-[100dvh]');
+  const mobileFullHeight = mobileFullClassName ?? (isMobileSplit ? 'h-[60dvh]' : 'h-[100dvh]');
+  const mobileSideHeight = mobileSideClassName ?? (isMobileSplit ? 'h-[40dvh]' : 'h-[100dvh]');
   const mobileSidePosition =
     mobileSideLayout === 'overlay' ? 'absolute inset-0 h-[100dvh]' : mobileSideHeight;
 
   return {
     wrapper:
-      'relative flex w-full flex-col md:absolute md:inset-0 md:grid md:max-h-screen md:max-h-[100dvh] md:flex-1 md:grid-cols-[8fr_4fr]',
+      'relative flex w-full flex-col lg:absolute lg:inset-0 lg:grid lg:max-h-screen lg:max-h-[100dvh] lg:flex-1 lg:grid-cols-[8fr_4fr]',
     full: cn(
-      `relative order-1 min-w-0 overflow-y-auto overflow-x-hidden md:overflow-hidden ${mobileFullHeight} md:order-none md:col-span-2 md:col-start-1 md:row-start-1 md:h-screen md:h-[100dvh]`,
+      `relative order-1 min-w-0 overflow-y-auto overflow-x-hidden lg:overflow-hidden ${mobileFullHeight} lg:order-none lg:col-span-2 lg:col-start-1 lg:row-start-1 lg:h-screen lg:h-[100dvh]`,
     ),
     side: cn(
-      `z-30 order-2 min-w-0 ${mobileSidePosition} pointer-events-none md:order-none md:relative md:col-start-2 md:row-start-1 md:h-screen md:h-[100dvh] md:inset-auto`,
+      `z-30 order-2 min-w-0 ${mobileSidePosition} pointer-events-none lg:order-none lg:relative lg:col-start-2 lg:row-start-1 lg:h-screen lg:h-[100dvh] lg:inset-auto`,
     ),
   };
 }

--- a/containers/frontend/web/src/components/primitives/split-screen-grid/split-screen-grid.tsx
+++ b/containers/frontend/web/src/components/primitives/split-screen-grid/split-screen-grid.tsx
@@ -10,6 +10,8 @@ export type SplitScreenGridProps = {
   side?: ReactNode;
   mobileStackMode?: SplitScreenGridMobileStackMode;
   mobileSideLayout?: SplitScreenGridMobileSideLayout;
+  mobileFullClassName?: string;
+  mobileSideClassName?: string;
 };
 
 export function SplitScreenGrid({
@@ -17,8 +19,10 @@ export function SplitScreenGrid({
   side,
   mobileStackMode = 'full',
   mobileSideLayout = 'stack',
+  mobileFullClassName,
+  mobileSideClassName,
 }: SplitScreenGridProps) {
-  const styles = splitScreenGridStyles({ mobileStackMode, mobileSideLayout });
+  const styles = splitScreenGridStyles({ mobileStackMode, mobileSideLayout, mobileFullClassName, mobileSideClassName });
 
   return (
     <main className={styles.wrapper}>

--- a/containers/frontend/web/src/features/direct-messages/messages-layout.styles.ts
+++ b/containers/frontend/web/src/features/direct-messages/messages-layout.styles.ts
@@ -2,21 +2,21 @@ import { cn } from '@/lib/styles/cn';
 
 export const messagesLayoutStyles = {
   root: 'pointer-events-auto relative flex h-[100dvh] w-full min-w-0 flex-1 overflow-hidden',
-  toggleButton: 'absolute right-4 top-16 z-20 pointer-events-auto md:hidden md:top-4',
+  toggleButton: 'absolute right-4 top-16 z-20 pointer-events-auto lg:hidden lg:top-4',
   overlay:
-    'absolute inset-0 z-10 flex pointer-events-none md:static md:z-auto md:flex-none md:pointer-events-auto',
+    'absolute inset-0 z-10 flex pointer-events-none lg:static lg:z-auto lg:flex-none lg:pointer-events-auto',
   backdrop: (isVisible: boolean) =>
     cn(
-      'absolute inset-0 bg-black/30 backdrop-blur-sm transition-opacity md:hidden',
+      'absolute inset-0 bg-black/30 backdrop-blur-sm transition-opacity lg:hidden',
       isVisible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
     ),
   panel: (isVisible: boolean) =>
     cn(
-      'relative flex h-full min-h-0 w-[min(24rem,calc(100vw-2rem))] max-w-full shrink-0 overflow-hidden transition-transform duration-300 md:ml-8 md:w-[400px] md:max-w-none md:translate-x-0',
+      'relative flex h-full min-h-0 w-[min(24rem,calc(100vw-2rem))] max-w-full shrink-0 overflow-hidden transition-transform duration-300 lg:ml-8 lg:w-[400px] lg:max-w-none lg:translate-x-0',
       isVisible ? 'translate-x-0 pointer-events-auto' : '-translate-x-full pointer-events-none',
-      'md:pointer-events-auto',
+      'lg:pointer-events-auto',
     ),
   panelInner:
-    'flex min-h-0 w-full overflow-hidden rounded-e-2xl border-r border-border-primary bg-bg-primary/95 shadow-xl backdrop-blur-md glass-fallback md:rounded-none md:border-none md:bg-transparent md:shadow-none md:backdrop-blur-none',
+    'flex min-h-0 w-full overflow-hidden rounded-e-2xl border-r border-border-primary bg-bg-primary/95 shadow-xl backdrop-blur-md glass-fallback lg:rounded-none lg:border-none lg:bg-transparent lg:shadow-none lg:backdrop-blur-none',
   content: 'flex min-h-0 min-w-0 flex-1 overflow-hidden',
 };

--- a/containers/frontend/web/src/features/navigation/navigation.client.styles.ts
+++ b/containers/frontend/web/src/features/navigation/navigation.client.styles.ts
@@ -23,7 +23,7 @@ export const navigationClientStyles = {
     ),
   mobileTrigger: (position: NavigationPosition, forceVisibleTrigger = false) =>
     cn(
-      forceVisibleTrigger ? '' : 'md:hidden',
+      forceVisibleTrigger ? '' : 'lg:hidden',
       navigationPositionClassNames[position].mobileTrigger,
       'pointer-events-auto right-4 top-3 z-[110]',
     ),

--- a/containers/frontend/web/src/features/navigation/navigation.client.tsx
+++ b/containers/frontend/web/src/features/navigation/navigation.client.tsx
@@ -135,7 +135,7 @@ export function NavigationClient({
   position = 'fixed',
   ...args
 }: NavigationClientProps) {
-  const isDesktop = useMediaQuery('(min-width: 768px)');
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
 
   if (mode === 'desktop') return <DesktopNavigation {...args} position={position} />;
   if (mode === 'mobile') return <MobileNavigation {...args} position={position} />;

--- a/containers/frontend/web/src/features/rooms/game-room-test.styles.ts
+++ b/containers/frontend/web/src/features/rooms/game-room-test.styles.ts
@@ -1,0 +1,13 @@
+export const gameRoomTestStyles = {
+  wrapper: 'h-full min-h-0',
+  header: 'px-4 pb-2 pt-10 lg:px-6 lg:pt-8',
+  content: 'px-4 pb-6 lg:px-6',
+  footer: 'px-4 pb-6 pt-2 lg:px-6',
+  sections: 'flex flex-col gap-4',
+  avatarSection: 'min-w-0',
+  avatarScroll: 'min-w-0 overflow-x-auto overflow-y-hidden',
+  avatarRow: 'flex w-max min-w-full gap-4 py-1',
+  avatarItem: 'flex w-20 min-w-20 shrink-0 flex-col items-center gap-1',
+  invitationAvatarItem: 'flex w-20 min-w-20 shrink-0 flex-col items-center gap-1 opacity-50',
+  avatarName: 'block w-full min-w-0 truncate text-center',
+} as const;

--- a/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
+++ b/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
@@ -57,9 +57,9 @@ export function GameRoomTest({
                   </Text>
                   <div className="flex flex-wrap gap-4">
                     {gameRoomStateCtx.teammates.map((user: PlayerState) => (
-                      <div key={user.userId} className="flex flex-col items-center gap-1">
+                      <div key={user.userId} className="flex w-9 min-w-0 flex-col items-center gap-1">
                         <Avatar size="lg" alt={user.userName} />
-                        <Text variant="body-xs" color="secondary">{user.userName}</Text>
+                        <Text variant="body-xs" color="secondary" className="w-full truncate text-center" title={user.userName}>{user.userName}</Text>
                       </div>
                     ))}
                   </div>

--- a/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
+++ b/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
@@ -2,7 +2,7 @@
 
 import type { FormEvent } from 'react';
 import { useTranslations } from 'next-intl';
-import { Stack, Text, Form, SubmitButton, ScrollArea, Avatar } from '@components';
+import { Stack, Text, Form, SubmitButton, Avatar } from '@components';
 
 import type { gameRoomState, PlayerState } from '@/contracts/sockets/rooms/gameRooms.schema';
 
@@ -12,6 +12,12 @@ import {
 } from '@/lib/sockets/game-room-socket.manager';
 
 import { SentRoomInvitations } from './sent-room-invitations';
+
+const AVATAR_COUNT = 4;
+function guestAvatarSrc(username: string): string {
+  const index = [...username].reduce((acc, c) => acc + c.charCodeAt(0), 0) % AVATAR_COUNT;
+  return `/avatars/avatar-${index + 1}.png`;
+}
 
 export function makeGameRoomAction(action: (formData: FormData) => void) {
   return (e: FormEvent<HTMLFormElement>) => {
@@ -26,87 +32,86 @@ type GameRoomTestProps = {
   gameRoomsErrorInfo: string;
 };
 
-export function GameRoomTest({
-  gameRoomStateCtx,
-  gameRoomsErrorInfo,
-}: GameRoomTestProps) {
+export function GameRoomTest({ gameRoomStateCtx, gameRoomsErrorInfo }: GameRoomTestProps) {
   const t = useTranslations('pages.home');
   const isInRoom = gameRoomStateCtx.id !== 0;
+  const teammateUsernames = new Set(gameRoomStateCtx.teammates.map((u: PlayerState) => u.userName));
 
   return (
     <Stack gap="none" className="h-full min-h-0">
       {isInRoom ? (
         <>
-          <div className="px-4 pt-14 pb-4 md:px-6 md:pt-8">
-            <Stack gap="xs">
-              <Text as="p" variant="caption" color="tertiary">
-                {t('room.label', { id: gameRoomStateCtx.id })}
+          <Stack gap="xs" className="px-4 pb-4 pt-14 md:px-6 md:pt-8">
+            <Text as="p" variant="caption" color="tertiary">
+              {t('room.label', { id: gameRoomStateCtx.id })}
+            </Text>
+            <Text as="h1" variant="heading-xl">
+              {gameRoomStateCtx.isGameRoomFull ? t('room.statusFull') : t('room.statusWaiting')}
+            </Text>
+          </Stack>
+
+          {gameRoomStateCtx.teammates.length > 0 && (
+            <section className="min-w-0 px-4 py-3 md:px-6" aria-labelledby="players-heading">
+              <Text as="h2" variant="caption" color="secondary" id="players-heading">
+                {t('room.playersHeading')}
               </Text>
-              <Text as="h1" variant="heading-xl">
-                {gameRoomStateCtx.isGameRoomFull ? t('room.statusFull') : t('room.statusWaiting')}
-              </Text>
-            </Stack>
-          </div>
+              <div className="min-w-0 overflow-x-auto overflow-y-hidden">
+                <div className="flex w-max min-w-full gap-4 py-1">
+                  {gameRoomStateCtx.teammates.map((user: PlayerState) => (
+                    <div
+                      key={user.userId}
+                      className="flex w-20 min-w-20 shrink-0 flex-col items-center gap-1"
+                    >
+                      <Avatar size="lg" src={guestAvatarSrc(user.userName)} alt={user.userName} />
+                      <Text
+                        variant="body-xs"
+                        color="secondary"
+                        className="block w-full min-w-0 truncate text-center"
+                        title={user.userName}
+                      >
+                        {user.userName}
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
 
-          <ScrollArea className="px-4 md:px-6">
-            <Stack gap="lg" className="pb-6">
-              {gameRoomStateCtx.teammates.length > 0 && (
-                <Stack gap="sm" as="section" aria-labelledby="players-heading">
-                  <Text as="h2" variant="caption" color="secondary" id="players-heading">
-                    {t('room.playersHeading')}
-                  </Text>
-                  <div className="flex flex-wrap gap-4">
-                    {gameRoomStateCtx.teammates.map((user: PlayerState) => (
-                      <div key={user.userId} className="flex w-9 min-w-0 flex-col items-center gap-1">
-                        <Avatar size="lg" alt={user.userName} />
-                        <Text variant="body-xs" color="secondary" className="w-full truncate text-center" title={user.userName}>{user.userName}</Text>
-                      </div>
-                    ))}
-                  </div>
-                </Stack>
-              )}
+          <SentRoomInvitations roomId={gameRoomStateCtx.id} teammateUsernames={teammateUsernames} />
 
-              <SentRoomInvitations
-                roomId={gameRoomStateCtx.id}
-                teammateUsernames={new Set(gameRoomStateCtx.teammates.map((u: PlayerState) => u.userName))}
-              />
-            </Stack>
-          </ScrollArea>
-
-          <div className="px-4 pb-6 pt-2 md:px-6">
+          <Stack gap="xs" className="px-4 pb-6 pt-2 md:px-6">
             {gameRoomsErrorInfo && (
-              <Text variant="caption" color="danger" className="mb-2">
+              <Text variant="caption" color="danger">
                 {gameRoomsErrorInfo}
               </Text>
             )}
             <Form onSubmit={makeGameRoomAction(GameRoomSocketLeaveRoom)}>
               <SubmitButton idleLabel={t('actions.leave')} />
             </Form>
-          </div>
+          </Stack>
         </>
       ) : (
         <>
-          <div className="px-4 pt-14 pb-4 md:px-6 md:pt-8">
-            <Stack gap="xs">
-              <Text as="h1" variant="heading-xl">
-                {t('title')}
-              </Text>
-              <Text as="p" variant="body" color="secondary">
-                {t('subtitle')}
-              </Text>
-            </Stack>
-          </div>
+          <Stack gap="xs" className="px-4 pb-4 pt-14 md:px-6 md:pt-8">
+            <Text as="h1" variant="heading-xl">
+              {t('title')}
+            </Text>
+            <Text as="p" variant="body" color="secondary">
+              {t('subtitle')}
+            </Text>
+          </Stack>
 
-          <div className="px-4 pb-6 pt-2 md:px-6">
+          <Stack gap="xs" className="px-4 pb-6 pt-2 md:px-6">
             {gameRoomsErrorInfo && (
-              <Text variant="caption" color="danger" className="mb-2">
+              <Text variant="caption" color="danger">
                 {gameRoomsErrorInfo}
               </Text>
             )}
             <Form onSubmit={makeGameRoomAction(GameRoomSocketJoinAnyRoom)}>
               <SubmitButton idleLabel={t('actions.join')} />
             </Form>
-          </div>
+          </Stack>
         </>
       )}
     </Stack>

--- a/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
+++ b/containers/frontend/web/src/features/rooms/gameRoomTest.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/sockets/game-room-socket.manager';
 
 import { SentRoomInvitations } from './sent-room-invitations';
+import { gameRoomTestStyles } from './game-room-test.styles';
 
 const AVATAR_COUNT = 4;
 function guestAvatarSrc(username: string): string {
@@ -38,10 +39,10 @@ export function GameRoomTest({ gameRoomStateCtx, gameRoomsErrorInfo }: GameRoomT
   const teammateUsernames = new Set(gameRoomStateCtx.teammates.map((u: PlayerState) => u.userName));
 
   return (
-    <Stack gap="none" className="h-full min-h-0">
+    <Stack gap="none" className={gameRoomTestStyles.wrapper}>
       {isInRoom ? (
         <>
-          <Stack gap="xs" className="px-4 pb-4 pt-14 md:px-6 md:pt-8">
+          <Stack gap="xs" className={gameRoomTestStyles.header}>
             <Text as="p" variant="caption" color="tertiary">
               {t('room.label', { id: gameRoomStateCtx.id })}
             </Text>
@@ -50,37 +51,39 @@ export function GameRoomTest({ gameRoomStateCtx, gameRoomsErrorInfo }: GameRoomT
             </Text>
           </Stack>
 
-          {gameRoomStateCtx.teammates.length > 0 && (
-            <section className="min-w-0 px-4 py-3 md:px-6" aria-labelledby="players-heading">
-              <Text as="h2" variant="caption" color="secondary" id="players-heading">
-                {t('room.playersHeading')}
-              </Text>
-              <div className="min-w-0 overflow-x-auto overflow-y-hidden">
-                <div className="flex w-max min-w-full gap-4 py-1">
-                  {gameRoomStateCtx.teammates.map((user: PlayerState) => (
-                    <div
-                      key={user.userId}
-                      className="flex w-20 min-w-20 shrink-0 flex-col items-center gap-1"
-                    >
-                      <Avatar size="lg" src={guestAvatarSrc(user.userName)} alt={user.userName} />
-                      <Text
-                        variant="body-xs"
-                        color="secondary"
-                        className="block w-full min-w-0 truncate text-center"
-                        title={user.userName}
-                      >
-                        {user.userName}
-                      </Text>
-                    </div>
-                  ))}
+          <Stack gap="md" className={gameRoomTestStyles.content}>
+            {gameRoomStateCtx.teammates.length > 0 && (
+              <section className={gameRoomTestStyles.avatarSection} aria-labelledby="players-heading">
+                <Text as="h2" variant="caption" color="secondary" id="players-heading">
+                  {t('room.playersHeading')}
+                </Text>
+                <div className={gameRoomTestStyles.avatarScroll}>
+                  <div className={gameRoomTestStyles.avatarRow}>
+                    {gameRoomStateCtx.teammates.map((user: PlayerState) => (
+                      <div key={user.userId} className={gameRoomTestStyles.avatarItem}>
+                        <Avatar size="lg" src={guestAvatarSrc(user.userName)} alt={user.userName} />
+                        <Text
+                          variant="body-xs"
+                          color="secondary"
+                          className={gameRoomTestStyles.avatarName}
+                          title={user.userName}
+                        >
+                          {user.userName}
+                        </Text>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            </section>
-          )}
+              </section>
+            )}
 
-          <SentRoomInvitations roomId={gameRoomStateCtx.id} teammateUsernames={teammateUsernames} />
+            <SentRoomInvitations
+              roomId={gameRoomStateCtx.id}
+              teammateUsernames={teammateUsernames}
+            />
+          </Stack>
 
-          <Stack gap="xs" className="px-4 pb-6 pt-2 md:px-6">
+          <Stack gap="xs" className={gameRoomTestStyles.footer}>
             {gameRoomsErrorInfo && (
               <Text variant="caption" color="danger">
                 {gameRoomsErrorInfo}
@@ -93,7 +96,7 @@ export function GameRoomTest({ gameRoomStateCtx, gameRoomsErrorInfo }: GameRoomT
         </>
       ) : (
         <>
-          <Stack gap="xs" className="px-4 pb-4 pt-14 md:px-6 md:pt-8">
+          <Stack gap="xs" className={gameRoomTestStyles.header}>
             <Text as="h1" variant="heading-xl">
               {t('title')}
             </Text>
@@ -102,7 +105,7 @@ export function GameRoomTest({ gameRoomStateCtx, gameRoomsErrorInfo }: GameRoomT
             </Text>
           </Stack>
 
-          <Stack gap="xs" className="px-4 pb-6 pt-2 md:px-6">
+          <Stack gap="xs" className={gameRoomTestStyles.footer}>
             {gameRoomsErrorInfo && (
               <Text variant="caption" color="danger">
                 {gameRoomsErrorInfo}

--- a/containers/frontend/web/src/features/rooms/sent-room-invitations.tsx
+++ b/containers/frontend/web/src/features/rooms/sent-room-invitations.tsx
@@ -58,9 +58,9 @@ export function SentRoomInvitations({ roomId, teammateUsernames }: RoomInvitatio
           </Text>
           <div className="flex flex-wrap gap-4">
             {filteredSent.map((inv) => (
-              <div key={inv.id} className="flex flex-col items-center gap-1 opacity-50">
+              <div key={inv.id} className="flex w-9 min-w-0 flex-col items-center gap-1 opacity-50">
                 <Avatar size="lg" alt={inv.friendUsername} />
-                <Text variant="body-xs" color="secondary">{inv.friendUsername}</Text>
+                <Text variant="body-xs" color="secondary" className="w-full truncate text-center" title={inv.friendUsername}>{inv.friendUsername}</Text>
               </div>
             ))}
           </div>
@@ -74,9 +74,9 @@ export function SentRoomInvitations({ roomId, teammateUsernames }: RoomInvitatio
           </Text>
           <div className="flex flex-wrap gap-4">
             {filteredReceived.map((inv) => (
-              <div key={inv.id} className="flex flex-col items-center gap-1 opacity-50">
+              <div key={inv.id} className="flex w-9 min-w-0 flex-col items-center gap-1 opacity-50">
                 <Avatar size="lg" alt={inv.friendUsername} />
-                <Text variant="body-xs" color="secondary">{inv.friendUsername}</Text>
+                <Text variant="body-xs" color="secondary" className="w-full truncate text-center" title={inv.friendUsername}>{inv.friendUsername}</Text>
               </div>
             ))}
           </div>

--- a/containers/frontend/web/src/features/rooms/sent-room-invitations.tsx
+++ b/containers/frontend/web/src/features/rooms/sent-room-invitations.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { Text, Avatar } from '@components';
 import { useGameInvitationsStore } from '@/features/game-invitations/store/game-invitations.provider';
+import { gameRoomTestStyles } from './game-room-test.styles';
 
 const AVATAR_COUNT = 4;
 function guestAvatarSrc(username: string): string {
@@ -56,24 +57,21 @@ export function SentRoomInvitations({ roomId, teammateUsernames }: RoomInvitatio
   if (!hasSent && !hasReceived) return null;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className={gameRoomTestStyles.sections}>
       {hasSent && (
-        <section className="min-w-0 px-4 py-3 md:px-6" aria-labelledby="sent-invitations-heading">
+        <section className={gameRoomTestStyles.avatarSection} aria-labelledby="sent-invitations-heading">
           <Text as="h2" variant="caption" color="secondary" id="sent-invitations-heading">
             {t('invitationsHeading')}
           </Text>
-          <div className="min-w-0 overflow-x-auto overflow-y-hidden">
-            <div className="flex w-max min-w-full gap-4 py-1">
+          <div className={gameRoomTestStyles.avatarScroll}>
+            <div className={gameRoomTestStyles.avatarRow}>
               {filteredSent.map((inv) => (
-                <div
-                  key={inv.id}
-                  className="flex w-20 min-w-20 shrink-0 flex-col items-center gap-1 opacity-50"
-                >
+                <div key={inv.id} className={gameRoomTestStyles.invitationAvatarItem}>
                   <Avatar size="lg" src={guestAvatarSrc(inv.friendUsername)} alt={inv.friendUsername} />
                   <Text
                     variant="body-xs"
                     color="secondary"
-                    className="block w-full min-w-0 truncate text-center"
+                    className={gameRoomTestStyles.avatarName}
                     title={inv.friendUsername}
                   >
                     {inv.friendUsername}
@@ -86,25 +84,19 @@ export function SentRoomInvitations({ roomId, teammateUsernames }: RoomInvitatio
       )}
 
       {hasReceived && (
-        <section
-          className="min-w-0 px-4 py-3 md:px-6"
-          aria-labelledby="received-invitations-heading"
-        >
+        <section className={gameRoomTestStyles.avatarSection} aria-labelledby="received-invitations-heading">
           <Text as="h2" variant="caption" color="secondary" id="received-invitations-heading">
             {t('receivedInvitationsHeading')}
           </Text>
-          <div className="min-w-0 overflow-x-auto overflow-y-hidden">
-            <div className="flex w-max min-w-full gap-4 py-1">
+          <div className={gameRoomTestStyles.avatarScroll}>
+            <div className={gameRoomTestStyles.avatarRow}>
               {filteredReceived.map((inv) => (
-                <div
-                  key={inv.id}
-                  className="flex w-20 min-w-20 shrink-0 flex-col items-center gap-1 opacity-50"
-                >
+                <div key={inv.id} className={gameRoomTestStyles.invitationAvatarItem}>
                   <Avatar size="lg" src={guestAvatarSrc(inv.friendUsername)} alt={inv.friendUsername} />
                   <Text
                     variant="body-xs"
                     color="secondary"
-                    className="block w-full min-w-0 truncate text-center"
+                    className={gameRoomTestStyles.avatarName}
                     title={inv.friendUsername}
                   >
                     {inv.friendUsername}

--- a/containers/frontend/web/src/features/rooms/sent-room-invitations.tsx
+++ b/containers/frontend/web/src/features/rooms/sent-room-invitations.tsx
@@ -2,8 +2,14 @@
 
 import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
-import { Stack, Text, Avatar } from '@components';
+import { Text, Avatar } from '@components';
 import { useGameInvitationsStore } from '@/features/game-invitations/store/game-invitations.provider';
+
+const AVATAR_COUNT = 4;
+function guestAvatarSrc(username: string): string {
+  const index = [...username].reduce((acc, c) => acc + c.charCodeAt(0), 0) % AVATAR_COUNT;
+  return `/avatars/avatar-${index + 1}.png`;
+}
 
 type RoomInvitationsProps = {
   roomId: number;
@@ -50,38 +56,65 @@ export function SentRoomInvitations({ roomId, teammateUsernames }: RoomInvitatio
   if (!hasSent && !hasReceived) return null;
 
   return (
-    <Stack gap="md">
+    <div className="flex flex-col gap-4">
       {hasSent && (
-        <Stack gap="sm" as="section" aria-labelledby="sent-invitations-heading">
+        <section className="min-w-0 px-4 py-3 md:px-6" aria-labelledby="sent-invitations-heading">
           <Text as="h2" variant="caption" color="secondary" id="sent-invitations-heading">
             {t('invitationsHeading')}
           </Text>
-          <div className="flex flex-wrap gap-4">
-            {filteredSent.map((inv) => (
-              <div key={inv.id} className="flex w-9 min-w-0 flex-col items-center gap-1 opacity-50">
-                <Avatar size="lg" alt={inv.friendUsername} />
-                <Text variant="body-xs" color="secondary" className="w-full truncate text-center" title={inv.friendUsername}>{inv.friendUsername}</Text>
-              </div>
-            ))}
+          <div className="min-w-0 overflow-x-auto overflow-y-hidden">
+            <div className="flex w-max min-w-full gap-4 py-1">
+              {filteredSent.map((inv) => (
+                <div
+                  key={inv.id}
+                  className="flex w-20 min-w-20 shrink-0 flex-col items-center gap-1 opacity-50"
+                >
+                  <Avatar size="lg" src={guestAvatarSrc(inv.friendUsername)} alt={inv.friendUsername} />
+                  <Text
+                    variant="body-xs"
+                    color="secondary"
+                    className="block w-full min-w-0 truncate text-center"
+                    title={inv.friendUsername}
+                  >
+                    {inv.friendUsername}
+                  </Text>
+                </div>
+              ))}
+            </div>
           </div>
-        </Stack>
+        </section>
       )}
 
       {hasReceived && (
-        <Stack gap="sm" as="section" aria-labelledby="received-invitations-heading">
+        <section
+          className="min-w-0 px-4 py-3 md:px-6"
+          aria-labelledby="received-invitations-heading"
+        >
           <Text as="h2" variant="caption" color="secondary" id="received-invitations-heading">
             {t('receivedInvitationsHeading')}
           </Text>
-          <div className="flex flex-wrap gap-4">
-            {filteredReceived.map((inv) => (
-              <div key={inv.id} className="flex w-9 min-w-0 flex-col items-center gap-1 opacity-50">
-                <Avatar size="lg" alt={inv.friendUsername} />
-                <Text variant="body-xs" color="secondary" className="w-full truncate text-center" title={inv.friendUsername}>{inv.friendUsername}</Text>
-              </div>
-            ))}
+          <div className="min-w-0 overflow-x-auto overflow-y-hidden">
+            <div className="flex w-max min-w-full gap-4 py-1">
+              {filteredReceived.map((inv) => (
+                <div
+                  key={inv.id}
+                  className="flex w-20 min-w-20 shrink-0 flex-col items-center gap-1 opacity-50"
+                >
+                  <Avatar size="lg" src={guestAvatarSrc(inv.friendUsername)} alt={inv.friendUsername} />
+                  <Text
+                    variant="body-xs"
+                    color="secondary"
+                    className="block w-full min-w-0 truncate text-center"
+                    title={inv.friendUsername}
+                  >
+                    {inv.friendUsername}
+                  </Text>
+                </div>
+              ))}
+            </div>
           </div>
-        </Stack>
+        </section>
       )}
-    </Stack>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the mobile dashboard layout so the game room actions, room status, players, and sent invitations remain visible or reachable on small screens.

Closes #326

## Changes

- Added mobile height overrides to `SplitScreenGrid`.
- Updated the dashboard split to give the game room panel more mobile height.
- Allowed the mobile full area to scroll vertically instead of clipping content.
- Moved game room spacing and avatar layout into a dedicated styles file.
- Fixed player/avatar rows to scroll horizontally only when needed.
- Truncated long usernames under avatars.
- Updated navigation, chat, and direct-message breakpoints from `md` to `lg` to avoid layout collisions on tablet/mobile widths.
- Updated prod HTTPS port mapping from `443:443` to `8443:443`.

## Validation

- [ ] Test mobile width `375px`.
- [ ] Test mobile width `390px`.
- [ ] Test mobile width `430px`.
- [ ] Confirm the join button is visible or reachable.
- [ ] Confirm room status is visible or reachable.
- [ ] Confirm players in room are visible or reachable.
- [ ] Confirm sent invitations are visible or reachable.
- [ ] Confirm avatar rows scroll horizontally without blocking vertical page scroll.
- [ ] Confirm desktop layout is unchanged.
- [ ] Run `docker compose exec frontend npm run lint`.
- [ ] Run `docker compose exec frontend npm run typecheck`.
- [ ] Run `docker compose exec frontend npm run build`.

## Notes

The port change fixes rootless Docker/prod startup issues caused by binding directly to privileged port `443`.