### PR TITLE
fix: reset realtime sockets when guest session upgrades to user

### DIFF
--- a/containers/frontend/web/src/features/auth/login/login.form.tsx
+++ b/containers/frontend/web/src/features/auth/login/login.form.tsx
@@ -11,6 +11,7 @@ import { type LoginReq } from '@/contracts/api/auth/auth.validation';
 import { loginAction } from './login.action';
 import { useAutoFocus } from '@/hooks/useAutoFocus';
 import { createSubmitHandler } from '@/lib/http/submitHandler';
+import { notifyAuthChanged } from '@/lib/sockets/realtime-session-bridge';
 
 export function LoginForm() {
   const t = useTranslations('features.auth');
@@ -18,8 +19,13 @@ export function LoginForm() {
   const [state, formAction] = useActionState(loginAction, null);
   const identifierRef = useAutoFocus<HTMLInputElement>();
 
+  const handleSubmit = createSubmitHandler(form, (formData) => {
+    notifyAuthChanged();
+    formAction(formData);
+  });
+
   return (
-    <Form onSubmit={createSubmitHandler(form, formAction)}>
+    <Form onSubmit={handleSubmit}>
       <TextField
         value={form.values.identifier}
         errorKey={form.errors.identifier && `validation.${form.errors.identifier}`}

--- a/containers/frontend/web/src/features/auth/oauth/oauth.tsx
+++ b/containers/frontend/web/src/features/auth/oauth/oauth.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@components';
 import type { ReactNode } from 'react';
+import { notifyAuthChanged } from '@/lib/sockets/realtime-session-bridge';
 
 function GoogleLogo() {
   return (
@@ -29,6 +30,7 @@ function GoogleLogo() {
 
 export function Oauth({ children }: { children: ReactNode }) {
   function startGoogleOauth(): void {
+    notifyAuthChanged();
     window.location.assign('/api/auth/google');
   }
 

--- a/containers/frontend/web/src/features/game-invitations/store/game-invitations.provider.tsx
+++ b/containers/frontend/web/src/features/game-invitations/store/game-invitations.provider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { createContext, useContext, useRef } from 'react';
+import { createContext, useContext, useEffect, useRef } from 'react';
 import { useStore } from 'zustand';
 
 import {
@@ -9,6 +9,7 @@ import {
   type GameInvitationsStore,
 } from './game-invitations.store';
 import type { GameInvitationsState } from './game-invitations.types';
+import { REALTIME_IDENTITY_CHANGED_EVENT } from '@/lib/sockets/realtime-session-bridge';
 
 export const GameInvitationsStoreContext = createContext<GameInvitationsStore | null>(null);
 
@@ -18,6 +19,20 @@ export function GameInvitationsProvider({ children }: { children: ReactNode }) {
   if (!storeRef.current) {
     storeRef.current = createGameInvitationsStore();
   }
+
+  useEffect(() => {
+    const store = storeRef.current;
+    if (!store) return;
+
+    const handleIdentityChanged = () => {
+      store.getState().resetInvitationState();
+    };
+
+    window.addEventListener(REALTIME_IDENTITY_CHANGED_EVENT, handleIdentityChanged);
+    return () => {
+      window.removeEventListener(REALTIME_IDENTITY_CHANGED_EVENT, handleIdentityChanged);
+    };
+  }, []);
 
   return (
     <GameInvitationsStoreContext.Provider value={storeRef.current}>

--- a/containers/frontend/web/src/features/rooms/rooms-provider.tsx
+++ b/containers/frontend/web/src/features/rooms/rooms-provider.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { createContext, useEffect, useState } from 'react';
 import type { gameRoomState } from '@/contracts/sockets/rooms/gameRooms.schema';
 import type { PlayerState } from "@/contracts/sockets/rooms/gameRooms.schema";
+import { REALTIME_IDENTITY_CHANGED_EVENT } from '@/lib/sockets/realtime-session-bridge';
 
 const ACTIVE_ROOM_STORAGE_KEY = 'transcendence:active-room-id';
 
@@ -40,6 +41,17 @@ export function RoomsProvider({
 
     window.sessionStorage.removeItem(ACTIVE_ROOM_STORAGE_KEY);
   }, [roomState.id]);
+
+  useEffect(() => {
+    const handleIdentityChanged = () => {
+      setRoomState(RoomStateEmpty);
+    };
+
+    window.addEventListener(REALTIME_IDENTITY_CHANGED_EVENT, handleIdentityChanged);
+    return () => {
+      window.removeEventListener(REALTIME_IDENTITY_CHANGED_EVENT, handleIdentityChanged);
+    };
+  }, []);
 
   const replaceTeammateName: RoomsStore['replaceTeammateName'] = ({
     nextUserName,

--- a/containers/frontend/web/src/lib/sockets/direct-messages-socket.manager.tsx
+++ b/containers/frontend/web/src/lib/sockets/direct-messages-socket.manager.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/contracts/sockets/direct-messages/direct-messages.schema';
 
 import { directMessagesSocket } from './direct-messages-socket.client';
+import { isSessionSyncedAsUser } from './realtime-session-bridge';
 
 type DirectMessagesSocketManagerProps = {
   friendUserId: string;
@@ -85,7 +86,7 @@ export function DirectMessagesSocketManager({
         console.error('Failed to initialize direct-messages session identity', error);
       })
       .finally(() => {
-        if (isMounted) {
+        if (isMounted && isSessionSyncedAsUser()) {
           directMessagesSocket.connect();
         }
       });

--- a/containers/frontend/web/src/lib/sockets/friends-socket.manager.ts
+++ b/containers/frontend/web/src/lib/sockets/friends-socket.manager.ts
@@ -19,6 +19,7 @@ import {
 } from '@/contracts/sockets/friendships/friendships.schema';
 
 import { friendsSocket } from './friends-socket.client';
+import { isSessionSyncedAsUser } from './realtime-session-bridge';
 
 type SocialSocketManagerProps = {
   onFriendOnline: (payload: PresenceOnlinePayload) => void;
@@ -132,7 +133,9 @@ export const SocialSocketManager = ({
 
     document.addEventListener('visibilitychange', emitCurrentPresence);
 
-    friendsSocket.connect();
+    if (isSessionSyncedAsUser() && !friendsSocket.connected) {
+      friendsSocket.connect();
+    }
 
     return () => {
       reservedListeners.forEach(([event, handler]) => {

--- a/containers/frontend/web/src/lib/sockets/realtime-session-bridge.tsx
+++ b/containers/frontend/web/src/lib/sockets/realtime-session-bridge.tsx
@@ -34,6 +34,12 @@ const AUTH_CHANGED_EVENT = 'transcendence:auth-changed';
 export const REALTIME_IDENTITY_CHANGED_EVENT = 'transcendence:realtime-identity-changed';
 const ACTIVE_ROOM_STORAGE_KEY = 'transcendence:active-room-id';
 
+let sessionSyncedAsUser = false;
+
+export function isSessionSyncedAsUser(): boolean {
+  return sessionSyncedAsUser;
+}
+
 function hasMountedListeners(socket: {
   listeners: (event: string) => unknown[];
 }) {
@@ -123,6 +129,7 @@ async function rejoinStoredRoomIfNeeded() {
 
 export function RealtimeSessionBridge() {
   const lastIdentityKeyRef = useRef<string | null>(null);
+  const lastIsGuestRef = useRef<boolean | null>(null);
   const pathname = usePathname();
 
   useEffect(() => {
@@ -136,36 +143,51 @@ export function RealtimeSessionBridge() {
 
       const nextIdentityKey = identity?.identityKey ?? null;
       const previousIdentityKey = lastIdentityKeyRef.current;
+      const previousIsGuest = lastIsGuestRef.current;
 
       if (previousIdentityKey === nextIdentityKey) {
         return;
       }
 
       lastIdentityKeyRef.current = nextIdentityKey;
+      lastIsGuestRef.current = identity?.isGuest ?? null;
       resetChatSessionIdentity();
       window.dispatchEvent(new CustomEvent(REALTIME_IDENTITY_CHANGED_EVENT));
 
       if (!nextIdentityKey) {
+        sessionSyncedAsUser = false;
         disconnectSocket(chatSocket);
         disconnectSocket(gameRoomSocket);
         disconnectSocket(gameSocket);
         disconnectSocket(friendsSocket);
         disconnectSocket(directMessagesSocket);
+        window.sessionStorage.removeItem(ACTIVE_ROOM_STORAGE_KEY);
         return;
       }
 
       disconnectSocket(chatSocket);
       disconnectSocket(gameSocket);
       disconnectSocket(gameRoomSocket);
+      disconnectSocket(friendsSocket);
+      disconnectSocket(directMessagesSocket);
 
-      await rejoinStoredRoomIfNeeded();
+      const wasGuest = previousIsGuest === true;
+      if (wasGuest) {
+        window.sessionStorage.removeItem(ACTIVE_ROOM_STORAGE_KEY);
+      } else {
+        await rejoinStoredRoomIfNeeded();
+      }
 
       restartSocket(chatSocket);
       restartSocket(gameSocket);
+      restartSocket(gameRoomSocket);
 
       if (identity?.isGuest === false && identity.userId) {
+        sessionSyncedAsUser = true;
         restartSocket(friendsSocket);
         restartSocket(directMessagesSocket);
+      } else {
+        sessionSyncedAsUser = false;
       }
     };
 
@@ -181,6 +203,7 @@ export function RealtimeSessionBridge() {
 
     return () => {
       isMounted = false;
+      sessionSyncedAsUser = false;
       window.removeEventListener(AUTH_CHANGED_EVENT, handleAuthChanged);
       window.removeEventListener('focus', handleAuthChanged);
       window.removeEventListener('pageshow', handleAuthChanged);


### PR DESCRIPTION
## Summary

This merge removes the guest-to-authenticated socket upgrade flow and replaces it with a safer realtime reset strategy when authentication changes.

Instead of trying to reuse guest socket connections after login or OAuth, the frontend now clears stale realtime state and waits for the authenticated session to be synced before opening user-only sockets.

## What changes

- Removes the previous guest socket upgrade behavior.
- Resets realtime state when authentication changes.
- Clears stale room and game invitation frontend state.
- Prevents friends and direct-message sockets from connecting before the user session is confirmed.
- Reduces stale guest/auth socket state after login or OAuth.
- Helps avoid `AUTH_UNAUTHORIZED` errors caused by sockets using the wrong identity.

## Why

Reusing guest sockets after authentication caused stale socket identity, room, and invitation state. This created inconsistent realtime behavior, especially after login, OAuth, and first application load.

The new approach is safer:

```txt
guest state
→ auth starts
→ reset realtime state
→ session sync completes
→ create authenticated sockets